### PR TITLE
Revamp GeoOverview to load IP timelines from stats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,66 +53,71 @@ OBJECTS_DIR   = ./
 ####### Files
 
 SOURCES       = devices/devices.cpp \
-		filter/filter.cpp \
-		packets/sniffing.cpp \
-		packets/packet_geolocation/geolocation.cpp \
-		packets/packet_geolocation/GeoMap.cpp \
-		src/main.cpp \
-		src/mainwindow.cpp \
-		src/packetworker.cpp \
-		src/coloring/packetcolorizer.cpp \
-		src/coloring/customizerdialog.cpp \
-		src/theme/theme.cpp \
-		src/theme/otherthemesdialog.cpp \
-		src/gui/mainwindow_ui.cpp \
-		src/gui/mainwindow_sniffing.cpp \
-		src/gui/mainwindow_packets.cpp \
-		src/statistics/statsdialog.cpp \
-		src/statistics/charts/barchart.cpp \
-		src/statistics/charts/linechart.cpp \
-		src/statistics/charts/pieChart.cpp \
-		src/statistics/statistics.cpp \
-		packets/packet_geolocation/CountryMapping/CountryMap.cpp \
-		src/PacketTableModel.cpp moc_mainwindow.cpp \
-		moc_packetworker.cpp \
-		moc_customizerdialog.cpp \
-		moc_otherthemesdialog.cpp \
-		moc_statsdialog.cpp \
-		moc_barchart.cpp \
-		moc_linechart.cpp \
-		moc_GeoMap.cpp \
-		moc_PacketTableModel.cpp
+                filter/filter.cpp \
+                packets/sniffing.cpp \
+                packets/packet_geolocation/geolocation.cpp \
+                packets/packet_geolocation/GeoMap.cpp \
+                src/main.cpp \
+                src/mainwindow.cpp \
+                src/packetworker.cpp \
+                src/coloring/packetcolorizer.cpp \
+                src/coloring/customizerdialog.cpp \
+                src/theme/theme.cpp \
+                src/theme/otherthemesdialog.cpp \
+                src/gui/mainwindow_ui.cpp \
+                src/gui/mainwindow_sniffing.cpp \
+                src/gui/mainwindow_packets.cpp \
+                src/statistics/geooverviewdialog.cpp \
+                src/statistics/statsdialog.cpp \
+                src/statistics/charts/barchart.cpp \
+                src/statistics/charts/linechart.cpp \
+                src/statistics/charts/pieChart.cpp \
+                src/statistics/statistics.cpp \
+                packets/packet_geolocation/CountryMapping/CountryMap.cpp \
+                src/PacketTableModel.cpp \
+                moc_mainwindow.cpp \
+                moc_packetworker.cpp \
+                moc_customizerdialog.cpp \
+                moc_otherthemesdialog.cpp \
+                moc_geooverviewdialog.cpp \
+                moc_statsdialog.cpp \
+                moc_barchart.cpp \
+                moc_linechart.cpp \
+                moc_GeoMap.cpp \
+                moc_PacketTableModel.cpp
 OBJECTS       = devices.o \
-		filter.o \
-		sniffing.o \
-		geolocation.o \
-		GeoMap.o \
-		main.o \
-		mainwindow.o \
-		packetworker.o \
-		packetcolorizer.o \
-		customizerdialog.o \
-		theme.o \
-		otherthemesdialog.o \
-		mainwindow_ui.o \
-		mainwindow_sniffing.o \
-		mainwindow_packets.o \
-		statsdialog.o \
-		barchart.o \
-		linechart.o \
-		pieChart.o \
-		statistics.o \
-		CountryMap.o \
-		PacketTableModel.o \
-		moc_mainwindow.o \
-		moc_packetworker.o \
-		moc_customizerdialog.o \
-		moc_otherthemesdialog.o \
-		moc_statsdialog.o \
-		moc_barchart.o \
-		moc_linechart.o \
-		moc_GeoMap.o \
-		moc_PacketTableModel.o
+                filter.o \
+                sniffing.o \
+                geolocation.o \
+                GeoMap.o \
+                main.o \
+                mainwindow.o \
+                packetworker.o \
+                packetcolorizer.o \
+                customizerdialog.o \
+                theme.o \
+                otherthemesdialog.o \
+                mainwindow_ui.o \
+                mainwindow_sniffing.o \
+                mainwindow_packets.o \
+                geooverviewdialog.o \
+                statsdialog.o \
+                barchart.o \
+                linechart.o \
+                pieChart.o \
+                statistics.o \
+                CountryMap.o \
+                PacketTableModel.o \
+                moc_mainwindow.o \
+                moc_packetworker.o \
+                moc_customizerdialog.o \
+                moc_otherthemesdialog.o \
+                moc_geooverviewdialog.o \
+                moc_statsdialog.o \
+                moc_barchart.o \
+                moc_linechart.o \
+                moc_GeoMap.o \
+                moc_PacketTableModel.o
 DIST          = /usr/lib/x86_64-linux-gnu/qt6/mkspecs/features/spec_pre.prf \
 		/usr/lib/x86_64-linux-gnu/qt6/mkspecs/common/unix.conf \
 		/usr/lib/x86_64-linux-gnu/qt6/mkspecs/common/linux.conf \
@@ -259,9 +264,10 @@ DIST          = /usr/lib/x86_64-linux-gnu/qt6/mkspecs/features/spec_pre.prf \
 		src/theme/otherthemesdialog.h \
 		src/gui/mainwindow_ui.h \
 		src/gui/mainwindow_sniffing.h \
-		src/gui/mainwindow_packets.h \
-		src/theme/ui_otherthemesdialog.h \
-		src/statistics/statsdialog.h \
+                src/gui/mainwindow_packets.h \
+                src/theme/ui_otherthemesdialog.h \
+                src/statistics/geooverviewdialog.h \
+                src/statistics/statsdialog.h \
 		src/statistics/charts/barchart.h \
 		src/statistics/charts/linechart.h \
 		src/statistics/charts/pieChart.h \
@@ -283,8 +289,9 @@ DIST          = /usr/lib/x86_64-linux-gnu/qt6/mkspecs/features/spec_pre.prf \
 		src/theme/otherthemesdialog.cpp \
 		src/gui/mainwindow_ui.cpp \
 		src/gui/mainwindow_sniffing.cpp \
-		src/gui/mainwindow_packets.cpp \
-		src/statistics/statsdialog.cpp \
+                src/gui/mainwindow_packets.cpp \
+                src/statistics/geooverviewdialog.cpp \
+                src/statistics/statsdialog.cpp \
 		src/statistics/charts/barchart.cpp \
 		src/statistics/charts/linechart.cpp \
 		src/statistics/charts/pieChart.cpp \
@@ -596,8 +603,8 @@ distdir: FORCE
 	@test -d $(DISTDIR) || mkdir -p $(DISTDIR)
 	$(COPY_FILE) --parents $(DIST) $(DISTDIR)/
 	$(COPY_FILE) --parents /usr/lib/x86_64-linux-gnu/qt6/mkspecs/features/data/dummy.cpp $(DISTDIR)/
-	$(COPY_FILE) --parents devices/devices.h filter/filter.h packets/sniffing.h packets/packet_geolocation/geolocation.h protocols/proto_struct.h src/mainwindow.h src/packetworker.h src/coloring/packetcolorizer.h src/coloring/customizerdialog.h src/coloring/coloringrule.h packets/packethelpers.h src/theme/theme.h src/theme/otherthemesdialog.h src/gui/mainwindow_ui.h src/gui/mainwindow_sniffing.h src/gui/mainwindow_packets.h src/theme/ui_otherthemesdialog.h src/statistics/statsdialog.h src/statistics/charts/barchart.h src/statistics/charts/linechart.h src/statistics/charts/pieChart.h src/statistics/statistics.h src/statistics/charts/ChartConfig.h packets/packet_geolocation/GeoMap.h packets/packet_geolocation/CountryMapping/CountryMap.h src/PacketTableModel.h $(DISTDIR)/
-	$(COPY_FILE) --parents devices/devices.cpp filter/filter.cpp packets/sniffing.cpp packets/packet_geolocation/geolocation.cpp packets/packet_geolocation/GeoMap.cpp src/main.cpp src/mainwindow.cpp src/packetworker.cpp src/coloring/packetcolorizer.cpp src/coloring/customizerdialog.cpp src/theme/theme.cpp src/theme/otherthemesdialog.cpp src/gui/mainwindow_ui.cpp src/gui/mainwindow_sniffing.cpp src/gui/mainwindow_packets.cpp src/statistics/statsdialog.cpp src/statistics/charts/barchart.cpp src/statistics/charts/linechart.cpp src/statistics/charts/pieChart.cpp src/statistics/statistics.cpp packets/packet_geolocation/CountryMapping/CountryMap.cpp src/PacketTableModel.cpp $(DISTDIR)/
+	$(COPY_FILE) --parents devices/devices.h filter/filter.h packets/sniffing.h packets/packet_geolocation/geolocation.h protocols/proto_struct.h src/mainwindow.h src/packetworker.h src/coloring/packetcolorizer.h src/coloring/customizerdialog.h src/coloring/coloringrule.h packets/packethelpers.h src/theme/theme.h src/theme/otherthemesdialog.h src/gui/mainwindow_ui.h src/gui/mainwindow_sniffing.h src/gui/mainwindow_packets.h src/theme/ui_otherthemesdialog.h src/statistics/geooverviewdialog.h src/statistics/statsdialog.h src/statistics/charts/barchart.h src/statistics/charts/linechart.h src/statistics/charts/pieChart.h src/statistics/statistics.h src/statistics/charts/ChartConfig.h packets/packet_geolocation/GeoMap.h packets/packet_geolocation/CountryMapping/CountryMap.h src/PacketTableModel.h $(DISTDIR)/
+	$(COPY_FILE) --parents devices/devices.cpp filter/filter.cpp packets/sniffing.cpp packets/packet_geolocation/geolocation.cpp packets/packet_geolocation/GeoMap.cpp src/main.cpp src/mainwindow.cpp src/packetworker.cpp src/coloring/packetcolorizer.cpp src/coloring/customizerdialog.cpp src/theme/theme.cpp src/theme/otherthemesdialog.cpp src/gui/mainwindow_ui.cpp src/gui/mainwindow_sniffing.cpp src/gui/mainwindow_packets.cpp src/statistics/geooverviewdialog.cpp src/statistics/statsdialog.cpp src/statistics/charts/barchart.cpp src/statistics/charts/linechart.cpp src/statistics/charts/pieChart.cpp src/statistics/statistics.cpp packets/packet_geolocation/CountryMapping/CountryMap.cpp src/PacketTableModel.cpp $(DISTDIR)/
 
 
 clean: compiler_clean 
@@ -629,9 +636,9 @@ compiler_moc_predefs_clean:
 moc_predefs.h: /usr/lib/x86_64-linux-gnu/qt6/mkspecs/features/data/dummy.cpp
 	g++ -pipe -O2 -std=gnu++1z -Wall -Wextra -dM -E -o moc_predefs.h /usr/lib/x86_64-linux-gnu/qt6/mkspecs/features/data/dummy.cpp
 
-compiler_moc_header_make_all: moc_mainwindow.cpp moc_packetworker.cpp moc_customizerdialog.cpp moc_otherthemesdialog.cpp moc_statsdialog.cpp moc_barchart.cpp moc_linechart.cpp moc_GeoMap.cpp moc_PacketTableModel.cpp
+compiler_moc_header_make_all: moc_mainwindow.cpp moc_packetworker.cpp moc_customizerdialog.cpp moc_otherthemesdialog.cpp moc_geooverviewdialog.cpp moc_statsdialog.cpp moc_barchart.cpp moc_linechart.cpp moc_GeoMap.cpp moc_PacketTableModel.cpp
 compiler_moc_header_clean:
-	-$(DEL_FILE) moc_mainwindow.cpp moc_packetworker.cpp moc_customizerdialog.cpp moc_otherthemesdialog.cpp moc_statsdialog.cpp moc_barchart.cpp moc_linechart.cpp moc_GeoMap.cpp moc_PacketTableModel.cpp
+	-$(DEL_FILE) moc_mainwindow.cpp moc_packetworker.cpp moc_customizerdialog.cpp moc_otherthemesdialog.cpp moc_geooverviewdialog.cpp moc_statsdialog.cpp moc_barchart.cpp moc_linechart.cpp moc_GeoMap.cpp moc_PacketTableModel.cpp
 moc_mainwindow.cpp: src/mainwindow.h \
 		src/packetworker.h \
 		packets/sniffing.h \
@@ -671,13 +678,22 @@ moc_customizerdialog.cpp: src/coloring/customizerdialog.h \
 	/usr/lib/qt6/libexec/moc $(DEFINES) --include /home/bartosz/Engineering/PacketSniffer/moc_predefs.h -I/usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -I/home/bartosz/Engineering/PacketSniffer -I/home/bartosz/Engineering/PacketSniffer/protocols -I/usr/include/x86_64-linux-gnu/qt6 -I/usr/include/x86_64-linux-gnu/qt6/QtSvgWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtSvg -I/usr/include/x86_64-linux-gnu/qt6/QtGui -I/usr/include/x86_64-linux-gnu/qt6/QtXml -I/usr/include/x86_64-linux-gnu/qt6/QtConcurrent -I/usr/include/x86_64-linux-gnu/qt6/QtCore -I/usr/include/c++/14 -I/usr/include/x86_64-linux-gnu/c++/14 -I/usr/include/c++/14/backward -I/usr/lib/gcc/x86_64-linux-gnu/14/include -I/usr/local/include -I/usr/include/x86_64-linux-gnu -I/usr/include src/coloring/customizerdialog.h -o moc_customizerdialog.cpp
 
 moc_otherthemesdialog.cpp: src/theme/otherthemesdialog.h \
-		moc_predefs.h \
-		/usr/lib/qt6/libexec/moc
+                moc_predefs.h \
+                /usr/lib/qt6/libexec/moc
 	/usr/lib/qt6/libexec/moc $(DEFINES) --include /home/bartosz/Engineering/PacketSniffer/moc_predefs.h -I/usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -I/home/bartosz/Engineering/PacketSniffer -I/home/bartosz/Engineering/PacketSniffer/protocols -I/usr/include/x86_64-linux-gnu/qt6 -I/usr/include/x86_64-linux-gnu/qt6/QtSvgWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtSvg -I/usr/include/x86_64-linux-gnu/qt6/QtGui -I/usr/include/x86_64-linux-gnu/qt6/QtXml -I/usr/include/x86_64-linux-gnu/qt6/QtConcurrent -I/usr/include/x86_64-linux-gnu/qt6/QtCore -I/usr/include/c++/14 -I/usr/include/x86_64-linux-gnu/c++/14 -I/usr/include/c++/14/backward -I/usr/lib/gcc/x86_64-linux-gnu/14/include -I/usr/local/include -I/usr/include/x86_64-linux-gnu -I/usr/include src/theme/otherthemesdialog.h -o moc_otherthemesdialog.cpp
 
+moc_geooverviewdialog.cpp: src/statistics/geooverviewdialog.h \
+                src/PacketTableModel.h \
+                packets/packet_geolocation/GeoMap.h \
+                packets/packet_geolocation/geolocation.h \
+                packets/packet_geolocation/CountryMapping/CountryMap.h \
+                moc_predefs.h \
+                /usr/lib/qt6/libexec/moc
+	/usr/lib/qt6/libexec/moc $(DEFINES) --include /home/bartosz/Engineering/PacketSniffer/moc_predefs.h -I/usr/lib/x86_64-linux-gnu/qt6/mkspecs/linux-g++ -I/home/bartosz/Engineering/PacketSniffer -I/home/bartosz/Engineering/PacketSniffer/protocols -I/usr/include/x86_64-linux-gnu/qt6 -I/usr/include/x86_64-linux-gnu/qt6/QtSvgWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtWidgets -I/usr/include/x86_64-linux-gnu/qt6/QtSvg -I/usr/include/x86_64-linux-gnu/qt6/QtGui -I/usr/include/x86_64-linux-gnu/qt6/QtXml -I/usr/include/x86_64-linux-gnu/qt6/QtConcurrent -I/usr/include/x86_64-linux-gnu/qt6/QtCore -I/usr/include/c++/14 -I/usr/include/x86_64-linux-gnu/c++/14 -I/usr/include/c++/14/backward -I/usr/lib/gcc/x86_64-linux-gnu/14/include -I/usr/local/include -I/usr/include/x86_64-linux-gnu -I/usr/include src/statistics/geooverviewdialog.h -o moc_geooverviewdialog.cpp
+
 moc_statsdialog.cpp: src/statistics/statsdialog.h \
-		src/statistics/charts/barchart.h \
-		src/statistics/charts/ChartConfig.h \
+                src/statistics/charts/barchart.h \
+                src/statistics/charts/ChartConfig.h \
 		src/statistics/charts/linechart.h \
 		moc_predefs.h \
 		/usr/lib/qt6/libexec/moc
@@ -854,32 +870,40 @@ mainwindow_sniffing.o: src/gui/mainwindow_sniffing.cpp src/gui/mainwindow_sniffi
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o mainwindow_sniffing.o src/gui/mainwindow_sniffing.cpp
 
 mainwindow_packets.o: src/gui/mainwindow_packets.cpp src/gui/mainwindow_packets.h \
-		src/mainwindow.h \
-		src/packetworker.h \
-		packets/sniffing.h \
-		protocols/proto_struct.h \
-		src/coloring/packetcolorizer.h \
-		src/coloring/coloringrule.h \
-		src/theme/theme.h \
-		src/theme/otherthemesdialog.h \
-		src/coloring/customizerdialog.h \
-		packets/packethelpers.h \
-		src/statistics/statsdialog.h \
-		src/statistics/charts/barchart.h \
-		src/statistics/charts/ChartConfig.h \
-		src/statistics/charts/linechart.h \
-		src/statistics/statistics.h \
-		src/statistics/charts/pieChart.h \
-		packets/packet_geolocation/geolocation.h \
-		packets/packet_geolocation/GeoMap.h \
-		packets/packet_geolocation/CountryMapping/CountryMap.h \
-		src/PacketTableModel.h
+                src/mainwindow.h \
+                src/packetworker.h \
+                packets/sniffing.h \
+                protocols/proto_struct.h \
+                src/coloring/packetcolorizer.h \
+                src/coloring/coloringrule.h \
+                src/theme/theme.h \
+                src/theme/otherthemesdialog.h \
+                src/coloring/customizerdialog.h \
+                packets/packethelpers.h \
+                src/statistics/geooverviewdialog.h \
+                src/statistics/statsdialog.h \
+                src/statistics/charts/barchart.h \
+                src/statistics/charts/ChartConfig.h \
+                src/statistics/charts/linechart.h \
+                src/statistics/statistics.h \
+                src/statistics/charts/pieChart.h \
+                packets/packet_geolocation/geolocation.h \
+                packets/packet_geolocation/GeoMap.h \
+                packets/packet_geolocation/CountryMapping/CountryMap.h \
+                src/PacketTableModel.h
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o mainwindow_packets.o src/gui/mainwindow_packets.cpp
 
+geooverviewdialog.o: src/statistics/geooverviewdialog.cpp src/statistics/geooverviewdialog.h \
+                src/PacketTableModel.h \
+                packets/packet_geolocation/GeoMap.h \
+                packets/packet_geolocation/geolocation.h \
+                packets/packet_geolocation/CountryMapping/CountryMap.h
+	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o geooverviewdialog.o src/statistics/geooverviewdialog.cpp
+
 statsdialog.o: src/statistics/statsdialog.cpp src/statistics/statsdialog.h \
-		src/statistics/charts/barchart.h \
-		src/statistics/charts/ChartConfig.h \
-		src/statistics/charts/linechart.h
+                src/statistics/charts/barchart.h \
+                src/statistics/charts/ChartConfig.h \
+                src/statistics/charts/linechart.h
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o statsdialog.o src/statistics/statsdialog.cpp
 
 barchart.o: src/statistics/charts/barchart.cpp src/statistics/charts/barchart.h \
@@ -917,10 +941,13 @@ moc_packetworker.o: moc_packetworker.cpp
 moc_customizerdialog.o: moc_customizerdialog.cpp 
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o moc_customizerdialog.o moc_customizerdialog.cpp
 
-moc_otherthemesdialog.o: moc_otherthemesdialog.cpp 
+moc_otherthemesdialog.o: moc_otherthemesdialog.cpp
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o moc_otherthemesdialog.o moc_otherthemesdialog.cpp
 
-moc_statsdialog.o: moc_statsdialog.cpp 
+moc_geooverviewdialog.o: moc_geooverviewdialog.cpp
+	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o moc_geooverviewdialog.o moc_geooverviewdialog.cpp
+
+moc_statsdialog.o: moc_statsdialog.cpp
 	$(CXX) -c $(CXXFLAGS) $(INCPATH) -o moc_statsdialog.o moc_statsdialog.cpp
 
 moc_barchart.o: moc_barchart.cpp 

--- a/PacketSniffer.pro
+++ b/PacketSniffer.pro
@@ -19,6 +19,7 @@ SOURCES += \
     src/gui/mainwindow_ui.cpp \
     src/gui/mainwindow_sniffing.cpp \
     src/gui/mainwindow_packets.cpp \
+    src/statistics/geooverviewdialog.cpp \
     src/statistics/statsdialog.cpp \
     src/statistics/charts/barChart.cpp \
     src/statistics/charts/lineChart.cpp \
@@ -44,6 +45,7 @@ HEADERS += \
     src/gui/mainwindow_ui.h \
     src/gui/mainwindow_sniffing.h \
     src/gui/mainwindow_packets.h \
+    src/statistics/geooverviewdialog.h \
     src/theme/ui_otherthemesdialog.h \
     src/statistics/statsdialog.h \
     src/statistics/charts/barChart.h \

--- a/packets/packet_geolocation/GeoMap.cpp
+++ b/packets/packet_geolocation/GeoMap.cpp
@@ -1,5 +1,9 @@
 #include "GeoMap.h"
 
+#include <QGraphicsScene>
+#include <QPainter>
+#include <QFont>
+
 GeoMapWidget::GeoMapWidget(const QString &svgMapFile, QWidget *parent)
     : QGraphicsView(parent),
       scene(new QGraphicsScene(this)),
@@ -19,12 +23,12 @@ GeoMapWidget::GeoMapWidget(const QString &svgMapFile, QWidget *parent)
     scene->setSceneRect(mapItem->boundingRect());
 
     setScene(scene);
+    setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
     fitInView(mapItem->boundingRect(), Qt::KeepAspectRatio);
 }
 
 void GeoMapWidget::highlightCountries(const QStringList &countryIds)
 {
-    
     QDomDocument doc = originalDoc;
     QDomElement root = doc.documentElement();
     for (const QString &cid : countryIds) {
@@ -40,19 +44,123 @@ void GeoMapWidget::highlightCountries(const QStringList &countryIds)
             if (!style.isEmpty()) {
                 if (style.contains("fill:")) {
                     style.replace(QRegularExpression("fill:[^;]+"),
-                                  "fill:#FF0000");
+                                  "fill:#FF6B6B");
                 } else {
-                    style += ";fill:#FF0000";
+                    style += ";fill:#FF6B6B";
                 }
                 path.setAttribute("style", style);
             } else {
-                path.setAttribute("fill", "#FF0000");
+                path.setAttribute("fill", "#FF6B6B");
             }
         }
     }
     QByteArray newSvg = doc.toByteArray();
     svgRenderer->load(newSvg);
     mapItem->update();
+}
+
+void GeoMapWidget::clearOverlay()
+{
+    resetAnimation();
+    currentFlightPath = QPainterPath();
+
+    if (flightPathItem)
+        flightPathItem->setVisible(false);
+    if (planeItem)
+        planeItem->setVisible(false);
+    if (srcMarker)
+        srcMarker->setVisible(false);
+    if (dstMarker)
+        dstMarker->setVisible(false);
+    if (flightLabel)
+        flightLabel->setVisible(false);
+}
+
+void GeoMapWidget::displayFlightPath(double srcLat, double srcLon,
+                                     double dstLat, double dstLon,
+                                     const QString &label,
+                                     int durationMs)
+{
+    // guard against invalid coordinates
+    if (!std::isfinite(srcLat) || !std::isfinite(srcLon) ||
+        !std::isfinite(dstLat) || !std::isfinite(dstLon)) {
+        clearOverlay();
+        emit flightAnimationFinished();
+        return;
+    }
+
+    ensureOverlayItems();
+
+    QPointF srcPoint = geoToPoint(srcLat, srcLon);
+    QPointF dstPoint = geoToPoint(dstLat, dstLon);
+
+    // If the scene rect is empty (e.g. map failed to load) bail out gracefully
+    if (scene->sceneRect().isEmpty()) {
+        clearOverlay();
+        emit flightAnimationFinished();
+        return;
+    }
+
+    resetAnimation();
+
+    // Compose a curved path between points for a "flight" arc
+    QPainterPath path(srcPoint);
+    QPointF mid = (srcPoint + dstPoint) / 2.0;
+    QPointF diff = dstPoint - srcPoint;
+    double length = std::hypot(diff.x(), diff.y());
+    QPointF normal(0.0, 0.0);
+    if (length > 0.0) {
+        normal = QPointF(-diff.y() / length, diff.x() / length);
+    }
+    double curveStrength = qMin(scene->sceneRect().width(), scene->sceneRect().height()) * 0.15;
+    QPointF control = mid + normal * curveStrength;
+    path.quadTo(control, dstPoint);
+
+    currentFlightPath = path;
+    flightPathItem->setPath(currentFlightPath);
+    flightPathItem->setVisible(true);
+
+    srcMarker->setPos(srcPoint);
+    srcMarker->setVisible(true);
+    dstMarker->setPos(dstPoint);
+    dstMarker->setVisible(true);
+
+    planeItem->setPos(srcPoint);
+    planeItem->setVisible(true);
+
+    if (flightLabel) {
+        flightLabel->setText(label);
+        QPointF labelPoint = currentFlightPath.pointAtPercent(0.5);
+        flightLabel->setPos(labelPoint + QPointF(10, -10));
+        flightLabel->setVisible(!label.isEmpty());
+    }
+
+    if (durationMs <= 0 || currentFlightPath.length() == 0.0) {
+        emit flightAnimationFinished();
+        return;
+    }
+
+    flightAnimation = new QVariantAnimation(this);
+    flightAnimation->setStartValue(0.0);
+    flightAnimation->setEndValue(1.0);
+    flightAnimation->setDuration(durationMs);
+    flightAnimation->setEasingCurve(QEasingCurve::InOutSine);
+
+    connect(flightAnimation, &QVariantAnimation::valueChanged, this, [this](const QVariant &value) {
+        double t = value.toDouble();
+        QPointF point = currentFlightPath.pointAtPercent(t);
+        planeItem->setPos(point);
+    });
+    connect(flightAnimation, &QVariantAnimation::finished, this, [this]() {
+        emit flightAnimationFinished();
+    });
+
+    flightAnimation->start();
+}
+
+void GeoMapWidget::stopFlightAnimation()
+{
+    resetAnimation();
 }
 
 void GeoMapWidget::resizeEvent(QResizeEvent *event)
@@ -75,4 +183,74 @@ QDomElement GeoMapWidget::findElementById(const QDomElement &parent,
         child = child.nextSiblingElement();
     }
     return QDomElement();
+}
+
+QPointF GeoMapWidget::geoToPoint(double lat, double lon) const
+{
+    // Clamp to map bounds
+    lat = std::clamp(lat, -90.0, 90.0);
+    lon = std::clamp(lon, -180.0, 180.0);
+
+    QRectF rect = mapItem->boundingRect();
+    double x = rect.left() + ((lon + 180.0) / 360.0) * rect.width();
+    double y = rect.top() + ((90.0 - lat) / 180.0) * rect.height();
+
+    return mapItem->mapToScene(QPointF(x, y));
+}
+
+void GeoMapWidget::ensureOverlayItems()
+{
+    if (!flightPathItem) {
+        flightPathItem = new QGraphicsPathItem;
+        flightPathItem->setZValue(5);
+        QPen pen(QColor("#2196F3"));
+        pen.setWidthF(2.0);
+        pen.setCapStyle(Qt::RoundCap);
+        pen.setJoinStyle(Qt::RoundJoin);
+        flightPathItem->setPen(pen);
+        scene->addItem(flightPathItem);
+    }
+    if (!planeItem) {
+        planeItem = new QGraphicsEllipseItem(-6, -6, 12, 12);
+        planeItem->setBrush(QColor("#FFD166"));
+        planeItem->setPen(Qt::NoPen);
+        planeItem->setZValue(6);
+        planeItem->setVisible(false);
+        scene->addItem(planeItem);
+    }
+    if (!srcMarker) {
+        srcMarker = new QGraphicsEllipseItem(-4, -4, 8, 8);
+        srcMarker->setBrush(QColor("#06D6A0"));
+        srcMarker->setPen(Qt::NoPen);
+        srcMarker->setZValue(6);
+        srcMarker->setVisible(false);
+        scene->addItem(srcMarker);
+    }
+    if (!dstMarker) {
+        dstMarker = new QGraphicsEllipseItem(-4, -4, 8, 8);
+        dstMarker->setBrush(QColor("#EF476F"));
+        dstMarker->setPen(Qt::NoPen);
+        dstMarker->setZValue(6);
+        dstMarker->setVisible(false);
+        scene->addItem(dstMarker);
+    }
+    if (!flightLabel) {
+        flightLabel = new QGraphicsSimpleTextItem;
+        QFont font = flightLabel->font();
+        font.setPointSizeF(font.pointSizeF() + 2.0);
+        flightLabel->setFont(font);
+        flightLabel->setBrush(Qt::white);
+        flightLabel->setZValue(7);
+        flightLabel->setVisible(false);
+        scene->addItem(flightLabel);
+    }
+}
+
+void GeoMapWidget::resetAnimation()
+{
+    if (flightAnimation) {
+        flightAnimation->stop();
+        flightAnimation->deleteLater();
+        flightAnimation = nullptr;
+    }
 }

--- a/packets/packet_geolocation/GeoMap.h
+++ b/packets/packet_geolocation/GeoMap.h
@@ -13,6 +13,17 @@
 #include <QDomDocument>
 #include <QDomElement>
 #include <QDomNodeList>
+#include <QGraphicsPathItem>
+#include <QGraphicsEllipseItem>
+#include <QGraphicsSimpleTextItem>
+#include <QVariantAnimation>
+#include <QEasingCurve>
+#include <QPainterPath>
+#include <QPen>
+#include <QBrush>
+
+#include <algorithm>
+#include <cmath>
 
 class GeoMapWidget : public QGraphicsView {
     Q_OBJECT
@@ -20,17 +31,37 @@ public:
     explicit GeoMapWidget(const QString &svgMapFile, QWidget *parent = nullptr);
 
     void highlightCountries(const QStringList &countryIds);
+    void clearOverlay();
+    void displayFlightPath(double srcLat, double srcLon,
+                           double dstLat, double dstLon,
+                           const QString &label,
+                           int durationMs = 2500);
+    void stopFlightAnimation();
+
+signals:
+    void flightAnimationFinished();
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
 
 private:
     QDomElement findElementById(const QDomElement &parent, const QString &id);
+    QPointF geoToPoint(double lat, double lon) const;
+    void ensureOverlayItems();
+    void resetAnimation();
 
     QGraphicsScene      *scene;
     QSvgRenderer        *svgRenderer;
     QGraphicsSvgItem    *mapItem;
     QByteArray           originalSvgData;
     QDomDocument         originalDoc;
+    QGraphicsPathItem   *flightPathItem = nullptr;
+    QGraphicsEllipseItem *planeItem = nullptr;
+    QGraphicsEllipseItem *srcMarker = nullptr;
+    QGraphicsEllipseItem *dstMarker = nullptr;
+    QGraphicsSimpleTextItem *flightLabel = nullptr;
+    QVariantAnimation   *flightAnimation = nullptr;
+    QPainterPath         currentFlightPath;
 };
-#endif //GEOMAP_H
+
+#endif // GEOMAP_H

--- a/src/gui/mainwindow_ui.cpp
+++ b/src/gui/mainwindow_ui.cpp
@@ -2,6 +2,7 @@
 #include "../theme/theme.h"
 #include "../coloring/customizerdialog.h"
 #include "../PacketTableModel.h"
+#include "../statistics/geooverviewdialog.h"
 #include <QMenu>
 #include <QMenuBar>
 #include <QCoreApplication>
@@ -155,8 +156,9 @@ void MainWindow::setupUI() {
         StatsDialog dlg(this);
         dlg.exec(); 
     });
-    statsMenu->addAction("GeoOverview", this, []() {
-        QMessageBox::information(nullptr, "GeoOverview", "World Map infos soon");
+    statsMenu->addAction("GeoOverview", this, [this]() {
+        GeoOverviewDialog dlg(&geo, this);
+        dlg.exec();
     });
 
 

--- a/src/statistics/geooverviewdialog.cpp
+++ b/src/statistics/geooverviewdialog.cpp
@@ -1,0 +1,622 @@
+#include "geooverviewdialog.h"
+
+#include "../../packets/packet_geolocation/GeoMap.h"
+#include "../../packets/packet_geolocation/geolocation.h"
+#include "../../packets/packet_geolocation/CountryMapping/CountryMap.h"
+
+#include <QAbstractItemView>
+#include <QCheckBox>
+#include <QCoreApplication>
+#include <QDateTimeEdit>
+#include <QDir>
+#include <QFile>
+#include <QGridLayout>
+#include <QHBoxLayout>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QLocale>
+#include <QPushButton>
+#include <QSignalBlocker>
+#include <QSlider>
+#include <QSplitter>
+#include <QTimer>
+#include <QVBoxLayout>
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+namespace {
+QString formatCountryLabel(const QString &country, const QString &fallback)
+{
+    if (!country.trimmed().isEmpty())
+        return country;
+    return fallback;
+}
+}
+
+GeoOverviewDialog::GeoOverviewDialog(GeoLocation *geo, QWidget *parent)
+    : QDialog(parent),
+      m_geo(geo)
+{
+    setWindowTitle(tr("GeoOverview"));
+    resize(1000, 720);
+
+    m_sessionsDir = QCoreApplication::applicationDirPath() + "/src/statistics/sessions";
+
+    auto *mainLayout = new QVBoxLayout(this);
+
+    auto *filterWidget = new QWidget(this);
+    auto *filterLayout = new QGridLayout(filterWidget);
+    filterLayout->setContentsMargins(0, 0, 0, 0);
+    filterLayout->setHorizontalSpacing(8);
+    filterLayout->setVerticalSpacing(4);
+
+    auto *ipLabel = new QLabel(tr("IP address"), filterWidget);
+    m_ipInput = new QLineEdit(filterWidget);
+    m_ipInput->setPlaceholderText(tr("e.g. 192.0.2.1"));
+    filterLayout->addWidget(ipLabel, 0, 0);
+    filterLayout->addWidget(m_ipInput, 0, 1, 1, 3);
+
+    m_startToggle = new QCheckBox(tr("From"), filterWidget);
+    m_startEdit = new QDateTimeEdit(QDateTime::currentDateTime(), filterWidget);
+    m_startEdit->setDisplayFormat(QStringLiteral("yyyy-MM-dd HH:mm:ss"));
+    m_startEdit->setCalendarPopup(true);
+    m_startEdit->setEnabled(false);
+    filterLayout->addWidget(m_startToggle, 1, 0);
+    filterLayout->addWidget(m_startEdit, 1, 1);
+
+    m_endToggle = new QCheckBox(tr("To"), filterWidget);
+    m_endEdit = new QDateTimeEdit(QDateTime::currentDateTime(), filterWidget);
+    m_endEdit->setDisplayFormat(QStringLiteral("yyyy-MM-dd HH:mm:ss"));
+    m_endEdit->setCalendarPopup(true);
+    m_endEdit->setEnabled(false);
+    filterLayout->addWidget(m_endToggle, 1, 2);
+    filterLayout->addWidget(m_endEdit, 1, 3);
+
+    m_searchButton = new QPushButton(tr("Load timeline"), filterWidget);
+    filterLayout->addWidget(m_searchButton, 0, 4, 2, 1);
+
+    filterLayout->setColumnStretch(1, 1);
+    filterLayout->setColumnStretch(3, 1);
+
+    mainLayout->addWidget(filterWidget);
+
+    const QString mapPath = QCoreApplication::applicationDirPath() + "/resources/WorldMap.svg";
+    m_map = new GeoMapWidget(mapPath, this);
+    m_map->setMinimumHeight(360);
+
+    connect(m_map, &GeoMapWidget::flightAnimationFinished,
+            this, &GeoOverviewDialog::handleFlightFinished);
+
+    auto *splitter = new QSplitter(Qt::Vertical);
+    splitter->addWidget(m_map);
+
+    QWidget *lowerPanel = new QWidget;
+    auto *lowerLayout = new QVBoxLayout(lowerPanel);
+    lowerLayout->setContentsMargins(0, 0, 0, 0);
+
+    auto *controlsLayout = new QHBoxLayout;
+    m_prevButton = new QPushButton(tr("⏮"));
+    m_playButton = new QPushButton(tr("Play"));
+    m_nextButton = new QPushButton(tr("⏭"));
+    m_slider = new QSlider(Qt::Horizontal);
+
+    m_prevButton->setToolTip(tr("Previous event"));
+    m_nextButton->setToolTip(tr("Next event"));
+    m_playButton->setToolTip(tr("Play / Pause"));
+
+    controlsLayout->addWidget(m_prevButton);
+    controlsLayout->addWidget(m_playButton);
+    controlsLayout->addWidget(m_nextButton);
+    controlsLayout->addWidget(m_slider, 1);
+
+    lowerLayout->addLayout(controlsLayout);
+
+    m_infoLabel = new QLabel;
+    m_infoLabel->setWordWrap(true);
+    m_detailLabel = new QLabel;
+    m_detailLabel->setWordWrap(true);
+    m_detailLabel->setStyleSheet(QStringLiteral("color: palette(mid);"));
+
+    lowerLayout->addWidget(m_infoLabel);
+    lowerLayout->addWidget(m_detailLabel);
+
+    m_eventList = new QListWidget;
+    m_eventList->setSelectionMode(QAbstractItemView::SingleSelection);
+    lowerLayout->addWidget(m_eventList, 1);
+
+    splitter->addWidget(lowerPanel);
+    splitter->setStretchFactor(0, 3);
+    splitter->setStretchFactor(1, 2);
+
+    mainLayout->addWidget(splitter);
+
+    connect(m_slider, &QSlider::valueChanged,
+            this, &GeoOverviewDialog::onSliderValueChanged);
+    connect(m_eventList, &QListWidget::currentRowChanged,
+            this, &GeoOverviewDialog::onEventSelectionChanged);
+    connect(m_playButton, &QPushButton::clicked,
+            this, &GeoOverviewDialog::togglePlayback);
+    connect(m_nextButton, &QPushButton::clicked,
+            this, &GeoOverviewDialog::playNext);
+    connect(m_prevButton, &QPushButton::clicked,
+            this, &GeoOverviewDialog::playPrevious);
+    connect(m_searchButton, &QPushButton::clicked,
+            this, &GeoOverviewDialog::performSearch);
+    connect(m_ipInput, &QLineEdit::returnPressed,
+            this, &GeoOverviewDialog::performSearch);
+    connect(m_startToggle, &QCheckBox::toggled,
+            this, &GeoOverviewDialog::handleStartFilterToggled);
+    connect(m_endToggle, &QCheckBox::toggled,
+            this, &GeoOverviewDialog::handleEndFilterToggled);
+
+    showEmptyState(tr("Awaiting selection"),
+                   tr("Provide an IP address and optionally a time range, then load the timeline."));
+    updateControlsState();
+}
+
+void GeoOverviewDialog::handleStartFilterToggled(bool checked)
+{
+    m_startEdit->setEnabled(checked);
+    if (checked && !m_startEdit->dateTime().isValid())
+        m_startEdit->setDateTime(QDateTime::currentDateTime());
+}
+
+void GeoOverviewDialog::handleEndFilterToggled(bool checked)
+{
+    m_endEdit->setEnabled(checked);
+    if (checked && !m_endEdit->dateTime().isValid())
+        m_endEdit->setDateTime(QDateTime::currentDateTime());
+}
+
+void GeoOverviewDialog::performSearch()
+{
+    if (m_isPlaying) {
+        m_isPlaying = false;
+        m_map->stopFlightAnimation();
+    }
+
+    const QString ip = m_ipInput->text().trimmed();
+    std::optional<QDateTime> start;
+    std::optional<QDateTime> end;
+
+    if (m_startToggle->isChecked())
+        start = m_startEdit->dateTime();
+    if (m_endToggle->isChecked())
+        end = m_endEdit->dateTime();
+
+    if (start && end && *start > *end)
+        std::swap(start, end);
+
+    loadEventsForIp(ip, start, end);
+    updateControlsState();
+
+    if (!m_events.isEmpty()) {
+        setCurrentEvent(0, false);
+    } else {
+        if (ip.isEmpty()) {
+            showEmptyState(tr("No IP selected"),
+                           tr("Enter an IP address to explore its history."));
+        } else {
+            QString detail;
+            if (start && end) {
+                detail = tr("No statistics found for %1 between %2 and %3.")
+                             .arg(ip,
+                                  QLocale::system().toString(*start, QLocale::ShortFormat),
+                                  QLocale::system().toString(*end,   QLocale::ShortFormat));
+            } else if (start) {
+                detail = tr("No statistics found for %1 after %2.")
+                             .arg(ip,
+                                  QLocale::system().toString(*start, QLocale::ShortFormat));
+            } else if (end) {
+                detail = tr("No statistics found for %1 before %2.")
+                             .arg(ip,
+                                  QLocale::system().toString(*end, QLocale::ShortFormat));
+            } else {
+                detail = tr("No statistics found for %1 in the stored sessions.")
+                             .arg(ip);
+            }
+            showEmptyState(tr("No timeline data"), detail);
+        }
+    }
+}
+
+void GeoOverviewDialog::showEmptyState(const QString &title, const QString &details)
+{
+    if (m_map) {
+        m_map->highlightCountries({});
+        m_map->clearOverlay();
+    }
+
+    if (m_infoLabel)
+        m_infoLabel->setText(title);
+    if (m_detailLabel)
+        m_detailLabel->setText(details);
+}
+
+void GeoOverviewDialog::loadEventsForIp(const QString &ip,
+                                        const std::optional<QDateTime> &start,
+                                        const std::optional<QDateTime> &end)
+{
+    m_eventList->clear();
+    m_events.clear();
+    m_currentIndex = -1;
+
+    if (ip.isEmpty()) {
+        auto *placeholder = new QListWidgetItem(tr("Enter an IP address to load events."));
+        placeholder->setFlags(Qt::NoItemFlags);
+        m_eventList->addItem(placeholder);
+        return;
+    }
+
+    QDir dir(m_sessionsDir);
+    QStringList files = dir.entryList({"*.json"}, QDir::Files, QDir::Name);
+
+    if (files.isEmpty()) {
+        auto *placeholder = new QListWidgetItem(tr("No statistics files available."));
+        placeholder->setFlags(Qt::NoItemFlags);
+        m_eventList->addItem(placeholder);
+        return;
+    }
+
+    QVector<FlightEvent> collected;
+    collected.reserve(256);
+
+    for (const QString &fileName : files) {
+        QFile file(dir.filePath(fileName));
+        if (!file.open(QIODevice::ReadOnly))
+            continue;
+
+        const QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+        file.close();
+        if (!doc.isObject())
+            continue;
+
+        const QJsonObject obj = doc.object();
+        const QDateTime sessionStart = QDateTime::fromString(obj.value("sessionStart").toString(), Qt::ISODate);
+        const QJsonArray perSecond = obj.value("perSecond").toArray();
+
+        for (const QJsonValue &secondValue : perSecond) {
+            const QJsonObject secondObj = secondValue.toObject();
+            const int sec = secondObj.value("second").toInt();
+            QDateTime timestamp = sessionStart.isValid()
+                                ? sessionStart.addSecs(sec)
+                                : QDateTime();
+
+            if (timestamp.isValid()) {
+                if (start && timestamp < *start)
+                    continue;
+                if (end && timestamp > *end)
+                    continue;
+            } else {
+                if (start || end)
+                    continue;
+            }
+
+            const QJsonArray connections = secondObj.value("connections").toArray();
+            QVector<QJsonObject> matches;
+            matches.reserve(connections.size());
+            for (const QJsonValue &connValue : connections) {
+                const QJsonObject connObj = connValue.toObject();
+                const QString src = connObj.value("src").toString();
+                const QString dst = connObj.value("dst").toString();
+                if (src == ip || dst == ip)
+                    matches.append(connObj);
+            }
+
+            if (matches.isEmpty())
+                continue;
+
+            const double pps = secondObj.value("pps").toDouble();
+            const double bps = secondObj.value("bps").toDouble();
+            const double avgPacketSize = secondObj.value("avgPacketSize").toDouble();
+            const QJsonObject protocols = secondObj.value("protocolCounts").toObject();
+
+            for (const QJsonObject &connObj : matches) {
+                FlightEvent event;
+                event.timestamp = timestamp;
+                event.srcIp = connObj.value("src").toString();
+                event.dstIp = connObj.value("dst").toString();
+                event.selectedIp = ip;
+                event.counterpartIp = (event.srcIp == ip) ? event.dstIp : event.srcIp;
+                event.direction = (event.srcIp == ip)
+                    ? tr("Outgoing to %1").arg(event.counterpartIp)
+                    : tr("Incoming from %1").arg(event.counterpartIp);
+                event.packetsPerSecond = pps;
+                event.bytesPerSecond = bps;
+                event.avgPacketSize = avgPacketSize;
+                for (auto it = protocols.constBegin(); it != protocols.constEnd(); ++it)
+                    event.protocolCounts.insert(it.key(), it.value().toDouble());
+                event.connectionsThisSecond = matches.size();
+
+                enrichWithGeo(event);
+                collected.push_back(event);
+            }
+        }
+    }
+
+    if (collected.isEmpty()) {
+        auto *placeholder = new QListWidgetItem(tr("No statistics found for %1.").arg(ip));
+        placeholder->setFlags(Qt::NoItemFlags);
+        m_eventList->addItem(placeholder);
+        return;
+    }
+
+    std::sort(collected.begin(), collected.end(), [](const FlightEvent &a, const FlightEvent &b) {
+        if (a.timestamp == b.timestamp)
+            return a.counterpartIp < b.counterpartIp;
+        if (!a.timestamp.isValid() || !b.timestamp.isValid())
+            return a.timestamp.isValid();
+        return a.timestamp < b.timestamp;
+    });
+
+    m_events = collected;
+    for (int i = 0; i < m_events.size(); ++i)
+        m_events[i].sequenceNumber = i + 1;
+
+    for (const FlightEvent &event : m_events) {
+        const QString timeStampText = event.timestamp.isValid()
+            ? QLocale::system().toString(event.timestamp, QLocale::ShortFormat)
+            : tr("Unknown time");
+        QString display = tr("%1. %2 • %3")
+            .arg(event.sequenceNumber)
+            .arg(timeStampText)
+            .arg(event.direction);
+        auto *item = new QListWidgetItem(display);
+        item->setToolTip(tr("%1 → %2\nConnections this second: %3")
+                         .arg(event.srcIp,
+                              event.dstIp,
+                              QString::number(event.connectionsThisSecond)));
+        m_eventList->addItem(item);
+    }
+}
+
+void GeoOverviewDialog::enrichWithGeo(FlightEvent &event)
+{
+    if (!m_geo)
+        return;
+
+    const QVector<GeoStruct> geoInfo = m_geo->GeoVector(event.srcIp, event.dstIp);
+    const QLocale locale = QLocale::c();
+
+    for (const GeoStruct &gs : geoInfo) {
+        const bool isSource = gs.name.startsWith(QStringLiteral("Source IP"));
+        const bool isDestination = gs.name.startsWith(QStringLiteral("Destination IP"));
+
+        QString country;
+        double latitude = std::numeric_limits<double>::quiet_NaN();
+        double longitude = std::numeric_limits<double>::quiet_NaN();
+
+        for (const auto &field : gs.fields) {
+            if (field.first == QStringLiteral("Country")) {
+                country = field.second;
+            } else if (field.first == QStringLiteral("Latitude")) {
+                bool latOk = false;
+                latitude = locale.toDouble(field.second, &latOk);
+                if (!latOk)
+                    latitude = field.second.toDouble(&latOk);
+                if (!latOk)
+                    latitude = std::numeric_limits<double>::quiet_NaN();
+            } else if (field.first == QStringLiteral("Longitude")) {
+                bool lonOk = false;
+                longitude = locale.toDouble(field.second, &lonOk);
+                if (!lonOk)
+                    longitude = field.second.toDouble(&lonOk);
+                if (!lonOk)
+                    longitude = std::numeric_limits<double>::quiet_NaN();
+            }
+        }
+
+        auto maybeIso = CountryMap::nameToIso().find(country);
+        if (maybeIso != CountryMap::nameToIso().end())
+            event.isoCodes << *maybeIso;
+
+        if (isSource) {
+            event.srcCountry = country;
+            event.srcLat = latitude;
+            event.srcLon = longitude;
+        } else if (isDestination) {
+            event.dstCountry = country;
+            event.dstLat = latitude;
+            event.dstLon = longitude;
+        }
+    }
+
+    event.isoCodes.removeDuplicates();
+    event.hasCoordinates = std::isfinite(event.srcLat) && std::isfinite(event.srcLon)
+                        && std::isfinite(event.dstLat) && std::isfinite(event.dstLon);
+}
+
+void GeoOverviewDialog::updateControlsState()
+{
+    const bool hasEvents = !m_events.isEmpty();
+    m_slider->setEnabled(hasEvents);
+    m_playButton->setEnabled(hasEvents);
+    m_prevButton->setEnabled(hasEvents);
+    m_nextButton->setEnabled(hasEvents);
+
+    if (hasEvents) {
+        m_slider->setRange(0, m_events.size() - 1);
+    } else {
+        m_slider->setRange(0, 0);
+        m_slider->setValue(0);
+    }
+
+    m_playButton->setText(m_isPlaying ? tr("Pause") : tr("Play"));
+}
+
+void GeoOverviewDialog::setCurrentEvent(int index, bool userInitiated)
+{
+    if (m_events.isEmpty())
+        return;
+
+    if (index < 0)
+        index = 0;
+    if (index >= m_events.size())
+        index = m_events.size() - 1;
+
+    if (userInitiated && m_isPlaying) {
+        m_isPlaying = false;
+        m_map->stopFlightAnimation();
+    }
+
+    m_currentIndex = index;
+
+    {
+        QSignalBlocker blockSlider(m_slider);
+        m_slider->setValue(index);
+    }
+    {
+        QSignalBlocker blockList(m_eventList);
+        m_eventList->setCurrentRow(index);
+    }
+
+    updateMapForEvent(m_events.at(index));
+    updateControlsState();
+}
+
+void GeoOverviewDialog::updateMapForEvent(const FlightEvent &event)
+{
+    if (!m_map)
+        return;
+
+    if (!event.isoCodes.isEmpty())
+        m_map->highlightCountries(event.isoCodes);
+    else
+        m_map->highlightCountries({});
+
+    const QString srcLabel = formatCountryLabel(event.srcCountry, event.srcIp);
+    const QString dstLabel = formatCountryLabel(event.dstCountry, event.dstIp);
+
+    QString headline = tr("%1. %2")
+        .arg(event.sequenceNumber)
+        .arg(event.direction);
+
+    if (event.timestamp.isValid()) {
+        headline.append(tr(" • %1")
+                        .arg(QLocale::system().toString(event.timestamp, QLocale::LongFormat)));
+    }
+
+    QStringList detailLines;
+    detailLines << tr("Route: %1 → %2").arg(srcLabel, dstLabel);
+    detailLines << tr("IPs: %1 → %2").arg(event.srcIp, event.dstIp);
+    detailLines << tr("Connections this second: %1")
+                   .arg(event.connectionsThisSecond);
+    detailLines << tr("Packets/s: %1 • Bytes/s: %2 • Avg pkt: %3 B")
+                   .arg(QString::number(event.packetsPerSecond, 'f', 0),
+                        QString::number(event.bytesPerSecond, 'f', 0),
+                        QString::number(event.avgPacketSize, 'f', 1));
+
+    if (!event.protocolCounts.isEmpty()) {
+        QStringList protoParts;
+        for (auto it = event.protocolCounts.constBegin();
+             it != event.protocolCounts.constEnd(); ++it) {
+            protoParts << tr("%1: %2").arg(it.key())
+                                        .arg(QString::number(it.value(), 'f', 0));
+        }
+        detailLines << tr("Protocols this second: %1").arg(protoParts.join(QLatin1String(", ")));
+    }
+
+    m_infoLabel->setText(headline);
+    m_detailLabel->setText(detailLines.join(QLatin1Char('\n')));
+
+    if (event.hasCoordinates) {
+        const QString flightLabel = tr("%1 → %2").arg(srcLabel, dstLabel);
+        m_map->displayFlightPath(event.srcLat, event.srcLon,
+                                 event.dstLat, event.dstLon,
+                                 flightLabel);
+    } else {
+        m_map->clearOverlay();
+        m_map->stopFlightAnimation();
+        if (m_isPlaying) {
+            QTimer::singleShot(600, this, &GeoOverviewDialog::handleFlightFinished);
+        }
+    }
+}
+
+void GeoOverviewDialog::onSliderValueChanged(int value)
+{
+    setCurrentEvent(value, true);
+}
+
+void GeoOverviewDialog::onEventSelectionChanged(int row)
+{
+    if (row < 0)
+        return;
+    setCurrentEvent(row, true);
+}
+
+void GeoOverviewDialog::togglePlayback()
+{
+    if (m_events.isEmpty())
+        return;
+
+    m_isPlaying = !m_isPlaying;
+    m_playButton->setText(m_isPlaying ? tr("Pause") : tr("Play"));
+
+    if (m_isPlaying) {
+        int targetIndex = m_currentIndex;
+        if (targetIndex < 0)
+            targetIndex = 0;
+        setCurrentEvent(targetIndex, false);
+    } else {
+        m_map->stopFlightAnimation();
+    }
+}
+
+void GeoOverviewDialog::playNext()
+{
+    if (m_events.isEmpty())
+        return;
+
+    if (m_isPlaying) {
+        m_isPlaying = false;
+        m_playButton->setText(tr("Play"));
+        m_map->stopFlightAnimation();
+    }
+
+    int nextIndex = m_currentIndex + 1;
+    if (nextIndex >= m_events.size())
+        nextIndex = 0;
+    setCurrentEvent(nextIndex, true);
+}
+
+void GeoOverviewDialog::playPrevious()
+{
+    if (m_events.isEmpty())
+        return;
+
+    if (m_isPlaying) {
+        m_isPlaying = false;
+        m_playButton->setText(tr("Play"));
+        m_map->stopFlightAnimation();
+    }
+
+    int prevIndex = m_currentIndex - 1;
+    if (prevIndex < 0)
+        prevIndex = m_events.size() - 1;
+    setCurrentEvent(prevIndex, true);
+}
+
+void GeoOverviewDialog::handleFlightFinished()
+{
+    if (!m_isPlaying || m_events.isEmpty())
+        return;
+
+    int nextIndex = m_currentIndex + 1;
+    if (nextIndex >= m_events.size())
+        nextIndex = 0;
+
+    if (nextIndex == m_currentIndex) {
+        m_isPlaying = false;
+        m_playButton->setText(tr("Play"));
+        return;
+    }
+
+    setCurrentEvent(nextIndex, false);
+}

--- a/src/statistics/geooverviewdialog.h
+++ b/src/statistics/geooverviewdialog.h
@@ -1,0 +1,94 @@
+#ifndef GEOOVERVIEWDIALOG_H
+#define GEOOVERVIEWDIALOG_H
+
+#include <QDialog>
+#include <QDateTime>
+#include <QMap>
+#include <QStringList>
+#include <QVector>
+#include <limits>
+#include <optional>
+
+class GeoMapWidget;
+class GeoLocation;
+class QListWidget;
+class QSlider;
+class QPushButton;
+class QLabel;
+class QLineEdit;
+class QCheckBox;
+class QDateTimeEdit;
+
+class GeoOverviewDialog : public QDialog {
+    Q_OBJECT
+public:
+    GeoOverviewDialog(GeoLocation *geo, QWidget *parent = nullptr);
+
+private slots:
+    void onSliderValueChanged(int value);
+    void onEventSelectionChanged(int row);
+    void togglePlayback();
+    void playNext();
+    void playPrevious();
+    void handleFlightFinished();
+    void performSearch();
+    void handleStartFilterToggled(bool checked);
+    void handleEndFilterToggled(bool checked);
+
+private:
+    struct FlightEvent {
+        int sequenceNumber = 0;
+        QDateTime timestamp;
+        QString srcIp;
+        QString dstIp;
+        QString selectedIp;
+        QString counterpartIp;
+        QString direction;
+        QString srcCountry;
+        QString dstCountry;
+        QStringList isoCodes;
+        double srcLat = std::numeric_limits<double>::quiet_NaN();
+        double srcLon = std::numeric_limits<double>::quiet_NaN();
+        double dstLat = std::numeric_limits<double>::quiet_NaN();
+        double dstLon = std::numeric_limits<double>::quiet_NaN();
+        bool hasCoordinates = false;
+        double packetsPerSecond = 0.0;
+        double bytesPerSecond = 0.0;
+        double avgPacketSize = 0.0;
+        QMap<QString, double> protocolCounts;
+        int connectionsThisSecond = 0;
+    };
+
+    void loadEventsForIp(const QString &ip,
+                         const std::optional<QDateTime> &start,
+                         const std::optional<QDateTime> &end);
+    void enrichWithGeo(FlightEvent &event);
+    void setCurrentEvent(int index, bool userInitiated);
+    void updateMapForEvent(const FlightEvent &event);
+    void updateControlsState();
+    void showEmptyState(const QString &title, const QString &details);
+
+    GeoLocation *m_geo = nullptr;
+    GeoMapWidget *m_map = nullptr;
+    QListWidget *m_eventList = nullptr;
+    QSlider *m_slider = nullptr;
+    QPushButton *m_playButton = nullptr;
+    QPushButton *m_nextButton = nullptr;
+    QPushButton *m_prevButton = nullptr;
+    QLabel *m_infoLabel = nullptr;
+    QLabel *m_detailLabel = nullptr;
+    QLineEdit *m_ipInput = nullptr;
+    QCheckBox *m_startToggle = nullptr;
+    QCheckBox *m_endToggle = nullptr;
+    QDateTimeEdit *m_startEdit = nullptr;
+    QDateTimeEdit *m_endEdit = nullptr;
+    QPushButton *m_searchButton = nullptr;
+
+    QString m_sessionsDir;
+
+    QVector<FlightEvent> m_events;
+    int m_currentIndex = -1;
+    bool m_isPlaying = false;
+};
+
+#endif // GEOOVERVIEWDIALOG_H


### PR DESCRIPTION
## Summary
- add IP and time range filters to the GeoOverview dialog with a dedicated timeline loader
- source playback events from stored statistics JSON files instead of the live packet table
- enrich the flight view with per-second metrics, protocol summaries, and clearer country information

## Testing
- make geooverviewdialog.o *(fails: /usr/bin/qmake is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de78e93d688325968022294f48f7f6