### PR TITLE
Add packet selection annotation dialog

### DIFF
--- a/PacketSniffer.pro
+++ b/PacketSniffer.pro
@@ -19,6 +19,7 @@ SOURCES += \
     src/gui/mainwindow_ui.cpp \
     src/gui/mainwindow_sniffing.cpp \
     src/gui/mainwindow_packets.cpp \
+    src/gui/selectionannotationdialog.cpp \
     src/statistics/geooverviewdialog.cpp \
     src/statistics/statsdialog.cpp \
     src/statistics/charts/barChart.cpp \
@@ -45,6 +46,7 @@ HEADERS += \
     src/gui/mainwindow_ui.h \
     src/gui/mainwindow_sniffing.h \
     src/gui/mainwindow_packets.h \
+    src/gui/selectionannotationdialog.h \
     src/statistics/geooverviewdialog.h \
     src/theme/ui_otherthemesdialog.h \
     src/statistics/statsdialog.h \

--- a/src/PacketTableModel.cpp
+++ b/src/PacketTableModel.cpp
@@ -66,3 +66,17 @@ void PacketTableModel::clear()
     endResetModel();
 }
 
+void PacketTableModel::setRowBackground(int index, const QColor &color)
+{
+    if (index < 0 || index >= m_rows.size())
+        return;
+
+    if (m_rows[index].background == color)
+        return;
+
+    m_rows[index].background = color;
+    const QModelIndex left = createIndex(index, 0);
+    const QModelIndex right = createIndex(index, ColumnCount - 1);
+    emit dataChanged(left, right, {Qt::BackgroundRole});
+}
+

--- a/src/PacketTableModel.h
+++ b/src/PacketTableModel.h
@@ -39,6 +39,7 @@ public:
     void addPacket(const PacketTableRow &row);
     PacketTableRow row(int index) const;
     void clear();
+    void setRowBackground(int index, const QColor &color);
 
 private:
     QVector<PacketTableRow> m_rows;

--- a/src/gui/selectionannotationdialog.cpp
+++ b/src/gui/selectionannotationdialog.cpp
@@ -1,0 +1,153 @@
+#include "selectionannotationdialog.h"
+
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QTextEdit>
+#include <QVBoxLayout>
+#include <QColorDialog>
+#include <algorithm>
+
+SelectionAnnotationDialog::SelectionAnnotationDialog(const QVector<int> &rows, QWidget *parent)
+    : QDialog(parent)
+    , m_rows(rows)
+    , m_color(QColor(255, 232, 128))
+{
+    setWindowTitle(tr("Annotate Packet Selection"));
+    setModal(true);
+
+    m_summaryLabel = new QLabel(this);
+    if (!m_rows.isEmpty()) {
+        QVector<int> sorted = m_rows;
+        std::sort(sorted.begin(), sorted.end());
+        QString summary;
+        if (sorted.size() == 1) {
+            summary = tr("Packet #%1").arg(sorted.first() + 1);
+        } else {
+            summary = tr("Packets #%1 – #%2 (%3 items)")
+                          .arg(sorted.first() + 1)
+                          .arg(sorted.last() + 1)
+                          .arg(sorted.size());
+        }
+        m_summaryLabel->setText(summary);
+    }
+
+    m_titleEdit = new QLineEdit(this);
+    m_titleEdit->setPlaceholderText(tr("Short title for this annotation"));
+
+    m_descriptionEdit = new QTextEdit(this);
+    m_descriptionEdit->setPlaceholderText(tr("Describe why this sequence matters…"));
+    m_descriptionEdit->setMinimumHeight(100);
+
+    m_threatCombo = new QComboBox(this);
+    m_threatCombo->addItems({
+        tr("Informational"),
+        tr("Benign"),
+        tr("Suspicious"),
+        tr("Malicious"),
+        tr("Critical")
+    });
+
+    m_tagsEdit = new QLineEdit(this);
+    m_tagsEdit->setPlaceholderText(tr("Additional tags (comma separated)"));
+
+    m_actionCombo = new QComboBox(this);
+    m_actionCombo->addItems({
+        tr("No immediate action"),
+        tr("Investigate further"),
+        tr("Block related traffic"),
+        tr("Notify response team"),
+        tr("Escalate incident")
+    });
+
+    m_colorButton = new QPushButton(this);
+    m_colorButton->setText(tr("Choose color"));
+    updateColorPreview();
+    connect(m_colorButton, &QPushButton::clicked,
+            this, &SelectionAnnotationDialog::chooseColor);
+
+    m_buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel,
+                                       Qt::Horizontal,
+                                       this);
+    connect(m_buttonBox, &QDialogButtonBox::accepted, this, &SelectionAnnotationDialog::accept);
+    connect(m_buttonBox, &QDialogButtonBox::rejected, this, &SelectionAnnotationDialog::reject);
+
+    auto *form = new QFormLayout;
+    form->addRow(tr("Selection"), m_summaryLabel);
+    form->addRow(tr("Title"), m_titleEdit);
+    form->addRow(tr("Description"), m_descriptionEdit);
+    form->addRow(tr("Threat level"), m_threatCombo);
+    form->addRow(tr("Tags"), m_tagsEdit);
+    form->addRow(tr("Recommended action"), m_actionCombo);
+    form->addRow(tr("Highlight"), m_colorButton);
+
+    auto *layout = new QVBoxLayout;
+    layout->addLayout(form);
+    layout->addWidget(m_buttonBox);
+
+    setLayout(layout);
+}
+
+SelectionAnnotationDialog::Result SelectionAnnotationDialog::result() const
+{
+    Result res;
+    res.title = m_titleEdit->text();
+    res.description = m_descriptionEdit->toPlainText();
+    res.threatLevel = m_threatCombo->currentText();
+    res.recommendedAction = m_actionCombo->currentText();
+
+    QStringList tags;
+    const QString baseTag = defaultTagForThreat();
+    if (!baseTag.isEmpty())
+        tags << baseTag;
+
+    const QString extra = m_tagsEdit->text();
+    for (const QString &tag : extra.split(',', Qt::SkipEmptyParts)) {
+        QString trimmed = tag.trimmed();
+        if (!trimmed.isEmpty())
+            tags << trimmed;
+    }
+    tags.removeDuplicates();
+    res.tags = tags;
+
+    res.color = m_color;
+
+    return res;
+}
+
+void SelectionAnnotationDialog::chooseColor()
+{
+    const QColor chosen = QColorDialog::getColor(m_color, this, tr("Choose highlight color"));
+    if (chosen.isValid()) {
+        m_color = chosen;
+        updateColorPreview();
+    }
+}
+
+void SelectionAnnotationDialog::updateColorPreview()
+{
+    const QString style = QStringLiteral("background-color: %1; color: %2;")
+                              .arg(m_color.name())
+                              .arg((m_color.lightness() < 128) ? QStringLiteral("white")
+                                                               : QStringLiteral("black"));
+    m_colorButton->setStyleSheet(style);
+}
+
+QString SelectionAnnotationDialog::defaultTagForThreat() const
+{
+    const QString threat = m_threatCombo->currentText();
+    if (threat.compare(tr("Benign"), Qt::CaseInsensitive) == 0) {
+        return QStringLiteral("safe");
+    }
+    if (threat.compare(tr("Suspicious"), Qt::CaseInsensitive) == 0) {
+        return QStringLiteral("suspicious");
+    }
+    if (threat.compare(tr("Malicious"), Qt::CaseInsensitive) == 0 ||
+        threat.compare(tr("Critical"), Qt::CaseInsensitive) == 0) {
+        return QStringLiteral("malware");
+    }
+    return QString();
+}

--- a/src/gui/selectionannotationdialog.h
+++ b/src/gui/selectionannotationdialog.h
@@ -1,0 +1,54 @@
+#ifndef SELECTIONANNOTATIONDIALOG_H
+#define SELECTIONANNOTATIONDIALOG_H
+
+#include <QColor>
+#include <QDialog>
+#include <QString>
+#include <QStringList>
+#include <QVector>
+
+class QComboBox;
+class QDialogButtonBox;
+class QLabel;
+class QLineEdit;
+class QPushButton;
+class QTextEdit;
+
+class SelectionAnnotationDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    struct Result {
+        QString title;
+        QString description;
+        QStringList tags;
+        QString threatLevel;
+        QString recommendedAction;
+        QColor color;
+    };
+
+    explicit SelectionAnnotationDialog(const QVector<int> &rows, QWidget *parent = nullptr);
+
+    Result result() const;
+
+private slots:
+    void chooseColor();
+
+private:
+    void updateColorPreview();
+    QString defaultTagForThreat() const;
+
+    QVector<int> m_rows;
+    QColor m_color;
+
+    QLabel *m_summaryLabel;
+    QLineEdit *m_titleEdit;
+    QTextEdit *m_descriptionEdit;
+    QComboBox *m_threatCombo;
+    QLineEdit *m_tagsEdit;
+    QComboBox *m_actionCombo;
+    QPushButton *m_colorButton;
+    QDialogButtonBox *m_buttonBox;
+};
+
+#endif // SELECTIONANNOTATIONDIALOG_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -26,6 +26,9 @@
 #include <QLabel>
 #include <QTimer>
 #include <QMap>
+#include <QDateTime>
+#include <QVector>
+#include <QStringList>
 #include <memory>
 #include <arpa/inet.h>
 #include <pcap.h>
@@ -43,6 +46,17 @@
 #include "packets/packet_geolocation/GeoMap.h"
 #include "packets/packet_geolocation/CountryMapping/CountryMap.h"
 #include "PacketTableModel.h"
+
+struct PacketAnnotation {
+    QVector<int> rows;
+    QString title;
+    QString description;
+    QStringList tags;
+    QString threatLevel;
+    QString recommendedAction;
+    QColor color;
+    QDateTime createdAt;
+};
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -106,13 +120,15 @@ private:
     QMap<QString,int>   protocolCounts;
 
     //charts
-    PieChart     *pieChart;   
+    PieChart     *pieChart;
     std::unique_ptr<Statistics> stats;
     QTimer *statsTimer = nullptr;
 
     //geolocation
     GeoLocation geo;
-    GeoMapWidget *mapWidget = nullptr;  
+    GeoMapWidget *mapWidget = nullptr;
+
+    QVector<PacketAnnotation> annotations;
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
## Summary
- add a dialog for annotating selected packets with descriptions, threat levels, tags, recommended actions, and highlight colors
- store packet annotations in the main window, recolor selected rows, and reset annotations when starting new sessions
- expose a model helper for updating row backgrounds and register the new dialog sources with the build

## Testing
- not run (Qt build tools not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68de85b799208325bad31ae18668bc89