### PR TITLE
Enhance packet reporting dialog

### DIFF
--- a/PacketSniffer.pro
+++ b/PacketSniffer.pro
@@ -19,6 +19,7 @@ SOURCES += \
     src/gui/mainwindow_ui.cpp \
     src/gui/mainwindow_sniffing.cpp \
     src/gui/mainwindow_packets.cpp \
+    src/gui/selectionannotationdialog.cpp \
     src/statistics/geooverviewdialog.cpp \
     src/statistics/statsdialog.cpp \
     src/statistics/charts/barChart.cpp \
@@ -45,6 +46,7 @@ HEADERS += \
     src/gui/mainwindow_ui.h \
     src/gui/mainwindow_sniffing.h \
     src/gui/mainwindow_packets.h \
+    src/gui/selectionannotationdialog.h \
     src/statistics/geooverviewdialog.h \
     src/theme/ui_otherthemesdialog.h \
     src/statistics/statsdialog.h \

--- a/src/PacketTableModel.cpp
+++ b/src/PacketTableModel.cpp
@@ -66,3 +66,17 @@ void PacketTableModel::clear()
     endResetModel();
 }
 
+void PacketTableModel::setRowBackground(int index, const QColor &color)
+{
+    if (index < 0 || index >= m_rows.size())
+        return;
+
+    if (m_rows[index].background == color)
+        return;
+
+    m_rows[index].background = color;
+    const QModelIndex left = createIndex(index, 0);
+    const QModelIndex right = createIndex(index, ColumnCount - 1);
+    emit dataChanged(left, right, {Qt::BackgroundRole});
+}
+

--- a/src/PacketTableModel.h
+++ b/src/PacketTableModel.h
@@ -39,6 +39,7 @@ public:
     void addPacket(const PacketTableRow &row);
     PacketTableRow row(int index) const;
     void clear();
+    void setRowBackground(int index, const QColor &color);
 
 private:
     QVector<PacketTableRow> m_rows;

--- a/src/gui/selectionannotationdialog.cpp
+++ b/src/gui/selectionannotationdialog.cpp
@@ -1,0 +1,250 @@
+#include "selectionannotationdialog.h"
+
+#include <QAbstractItemView>
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QTableWidget>
+#include <QTableWidgetItem>
+#include <QTextEdit>
+#include <QVBoxLayout>
+#include <QColorDialog>
+
+#include <algorithm>
+
+SelectionAnnotationDialog::SelectionAnnotationDialog(const QVector<PacketSummary> &packets,
+                                                     QWidget *parent)
+    : QDialog(parent)
+    , m_packets(packets)
+{
+    setWindowTitle(tr("Report Selection"));
+    setModal(true);
+
+    m_summaryLabel = new QLabel(this);
+    if (!m_packets.isEmpty()) {
+        QVector<int> rows;
+        rows.reserve(m_packets.size());
+        for (const auto &pkt : m_packets)
+            rows.append(pkt.row);
+        std::sort(rows.begin(), rows.end());
+
+        QString summary;
+        if (rows.size() == 1) {
+            summary = tr("Packet #%1").arg(rows.first() + 1);
+        } else {
+            summary = tr("Packets #%1 – #%2 (%3 items)")
+                          .arg(rows.first() + 1)
+                          .arg(rows.last() + 1)
+                          .arg(rows.size());
+        }
+        m_summaryLabel->setText(summary);
+    }
+
+    m_packetTable = new QTableWidget(this);
+    m_packetTable->setColumnCount(8);
+    m_packetTable->setHorizontalHeaderLabels({
+        tr("No."),
+        tr("Time"),
+        tr("Source"),
+        tr("Destination"),
+        tr("Protocol"),
+        tr("Info"),
+        tr("Tags"),
+        tr("Highlight")
+    });
+    m_packetTable->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+    m_packetTable->horizontalHeader()->setStretchLastSection(true);
+    m_packetTable->verticalHeader()->setVisible(false);
+    m_packetTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_packetTable->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    m_packetTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+
+    m_packetTable->setRowCount(m_packets.size());
+    m_packetColors.resize(m_packets.size(), QColor(255, 232, 128));
+    m_packetTagEdits.resize(m_packets.size());
+    m_packetColorButtons.resize(m_packets.size());
+
+    for (int row = 0; row < m_packets.size(); ++row) {
+        const PacketSummary &pkt = m_packets.at(row);
+
+        auto insertItem = [this, row](int column, const QString &text) {
+            auto *item = new QTableWidgetItem(text);
+            item->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+            m_packetTable->setItem(row, column, item);
+        };
+
+        insertItem(0, pkt.number);
+        insertItem(1, pkt.time);
+        insertItem(2, pkt.source);
+        insertItem(3, pkt.destination);
+        insertItem(4, pkt.protocol);
+        insertItem(5, pkt.info);
+
+        auto *tagEdit = new QLineEdit(this);
+        tagEdit->setPlaceholderText(tr("Tags for packet %1").arg(pkt.number));
+        m_packetTagEdits[row] = tagEdit;
+        m_packetTable->setCellWidget(row, 6, tagEdit);
+
+        auto *colorButton = new QPushButton(tr("Choose…"), this);
+        m_packetColorButtons[row] = colorButton;
+        updateColorButton(row);
+        m_packetTable->setCellWidget(row, 7, colorButton);
+        connect(colorButton, &QPushButton::clicked, this, [this, row]() {
+            chooseColorForRow(row);
+        });
+    }
+
+    m_titleEdit = new QLineEdit(this);
+    m_titleEdit->setPlaceholderText(tr("Short title for this report"));
+
+    m_descriptionEdit = new QTextEdit(this);
+    m_descriptionEdit->setPlaceholderText(tr("Describe why this sequence matters…"));
+    m_descriptionEdit->setMinimumHeight(100);
+
+    m_threatCombo = new QComboBox(this);
+    m_threatCombo->addItems({
+        tr("Informational"),
+        tr("Benign"),
+        tr("Suspicious"),
+        tr("Malicious"),
+        tr("Critical")
+    });
+
+    m_tagsEdit = new QLineEdit(this);
+    m_tagsEdit->setPlaceholderText(tr("Global tags (comma separated)"));
+
+    m_actionCombo = new QComboBox(this);
+    m_actionCombo->addItems({
+        tr("No immediate action"),
+        tr("Investigate further"),
+        tr("Block related traffic"),
+        tr("Notify response team"),
+        tr("Escalate incident")
+    });
+
+    m_buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel,
+                                       Qt::Horizontal,
+                                       this);
+    connect(m_buttonBox, &QDialogButtonBox::accepted, this, &SelectionAnnotationDialog::accept);
+    connect(m_buttonBox, &QDialogButtonBox::rejected, this, &SelectionAnnotationDialog::reject);
+
+    auto *form = new QFormLayout;
+    form->addRow(tr("Title"), m_titleEdit);
+    form->addRow(tr("Description"), m_descriptionEdit);
+    form->addRow(tr("Threat level"), m_threatCombo);
+    form->addRow(tr("Global tags"), m_tagsEdit);
+    form->addRow(tr("Recommended action"), m_actionCombo);
+
+    auto *layout = new QVBoxLayout;
+    if (!m_summaryLabel->text().isEmpty())
+        layout->addWidget(m_summaryLabel);
+    layout->addWidget(m_packetTable);
+    layout->addLayout(form);
+    layout->addWidget(m_buttonBox);
+
+    setLayout(layout);
+}
+
+SelectionAnnotationDialog::Result SelectionAnnotationDialog::result() const
+{
+    Result res;
+    res.title = m_titleEdit->text();
+    res.description = m_descriptionEdit->toPlainText();
+    res.threatLevel = m_threatCombo->currentText();
+    res.recommendedAction = m_actionCombo->currentText();
+
+    QStringList baseTags = splitTags(m_tagsEdit->text());
+    const QString autoTag = defaultTagForThreat();
+    if (!autoTag.isEmpty())
+        baseTags.prepend(autoTag);
+    baseTags.removeDuplicates();
+    res.tags = baseTags;
+
+    res.packets.reserve(m_packets.size());
+    for (int i = 0; i < m_packets.size(); ++i) {
+        Result::PacketDetail detail;
+        detail.row = m_packets.at(i).row;
+
+        QStringList perPacketTags = baseTags;
+        if (i < m_packetTagEdits.size() && m_packetTagEdits.at(i)) {
+            const QString text = m_packetTagEdits.at(i)->text();
+            const QStringList extra = splitTags(text);
+            for (const QString &tag : extra)
+                perPacketTags.append(tag);
+        }
+        perPacketTags.removeDuplicates();
+        detail.tags = perPacketTags;
+
+        if (i < m_packetColors.size())
+            detail.color = m_packetColors.at(i);
+
+        res.packets.append(detail);
+    }
+
+    return res;
+}
+
+void SelectionAnnotationDialog::chooseColorForRow(int row)
+{
+    if (row < 0 || row >= m_packetColors.size())
+        return;
+
+    const QColor current = m_packetColors.value(row);
+    const QColor chosen = QColorDialog::getColor(current, this, tr("Choose highlight color"));
+    if (!chosen.isValid())
+        return;
+
+    m_packetColors[row] = chosen;
+    updateColorButton(row);
+}
+
+QStringList SelectionAnnotationDialog::splitTags(const QString &text) const
+{
+    QStringList tags;
+    const QStringList parts = text.split(',', Qt::SkipEmptyParts);
+    for (const QString &part : parts) {
+        const QString trimmed = part.trimmed();
+        if (!trimmed.isEmpty())
+            tags << trimmed;
+    }
+    return tags;
+}
+
+QString SelectionAnnotationDialog::defaultTagForThreat() const
+{
+    const QString threat = m_threatCombo->currentText();
+    if (threat.compare(tr("Benign"), Qt::CaseInsensitive) == 0) {
+        return QStringLiteral("safe");
+    }
+    if (threat.compare(tr("Suspicious"), Qt::CaseInsensitive) == 0) {
+        return QStringLiteral("suspicious");
+    }
+    if (threat.compare(tr("Malicious"), Qt::CaseInsensitive) == 0 ||
+        threat.compare(tr("Critical"), Qt::CaseInsensitive) == 0) {
+        return QStringLiteral("malware");
+    }
+    return QString();
+}
+
+void SelectionAnnotationDialog::updateColorButton(int row)
+{
+    if (row < 0 || row >= m_packetColorButtons.size())
+        return;
+
+    QPushButton *button = m_packetColorButtons.at(row);
+    if (!button)
+        return;
+
+    const QColor color = m_packetColors.value(row, QColor(255, 232, 128));
+    const QString foreground = (color.lightness() < 128)
+        ? QStringLiteral("white")
+        : QStringLiteral("black");
+    const QString style = QStringLiteral("background-color: %1; color: %2;")
+                              .arg(color.name())
+                              .arg(foreground);
+    button->setStyleSheet(style);
+}

--- a/src/gui/selectionannotationdialog.h
+++ b/src/gui/selectionannotationdialog.h
@@ -1,0 +1,75 @@
+#ifndef SELECTIONANNOTATIONDIALOG_H
+#define SELECTIONANNOTATIONDIALOG_H
+
+#include <QColor>
+#include <QDialog>
+#include <QString>
+#include <QStringList>
+#include <QVector>
+
+class QComboBox;
+class QDialogButtonBox;
+class QLabel;
+class QLineEdit;
+class QPushButton;
+class QTextEdit;
+class QTableWidget;
+
+class SelectionAnnotationDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    struct PacketSummary {
+        int row = -1;
+        QString number;
+        QString time;
+        QString source;
+        QString destination;
+        QString protocol;
+        QString info;
+    };
+
+    struct Result {
+        struct PacketDetail {
+            int row = -1;
+            QStringList tags;
+            QColor color;
+        };
+
+        QString title;
+        QString description;
+        QStringList tags;
+        QString threatLevel;
+        QString recommendedAction;
+        QVector<PacketDetail> packets;
+    };
+
+    explicit SelectionAnnotationDialog(const QVector<PacketSummary> &packets,
+                                       QWidget *parent = nullptr);
+
+    Result result() const;
+
+private slots:
+    void chooseColorForRow(int row);
+
+private:
+    QStringList splitTags(const QString &text) const;
+    QString defaultTagForThreat() const;
+    void updateColorButton(int row);
+
+    QVector<PacketSummary> m_packets;
+    QVector<QColor> m_packetColors;
+    QVector<QLineEdit*> m_packetTagEdits;
+    QVector<QPushButton*> m_packetColorButtons;
+
+    QLabel *m_summaryLabel;
+    QLineEdit *m_titleEdit;
+    QTextEdit *m_descriptionEdit;
+    QComboBox *m_threatCombo;
+    QLineEdit *m_tagsEdit;
+    QComboBox *m_actionCombo;
+    QTableWidget *m_packetTable;
+    QDialogButtonBox *m_buttonBox;
+};
+
+#endif // SELECTIONANNOTATIONDIALOG_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -26,6 +26,9 @@
 #include <QLabel>
 #include <QTimer>
 #include <QMap>
+#include <QDateTime>
+#include <QVector>
+#include <QStringList>
 #include <memory>
 #include <arpa/inet.h>
 #include <pcap.h>
@@ -43,6 +46,22 @@
 #include "packets/packet_geolocation/GeoMap.h"
 #include "packets/packet_geolocation/CountryMapping/CountryMap.h"
 #include "PacketTableModel.h"
+
+struct PacketAnnotationItem {
+    int row = -1;
+    QStringList tags;
+    QColor color;
+};
+
+struct PacketAnnotation {
+    QString title;
+    QString description;
+    QStringList tags;
+    QString threatLevel;
+    QString recommendedAction;
+    QVector<PacketAnnotationItem> packets;
+    QDateTime createdAt;
+};
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -71,7 +90,8 @@ private:
     void listInterfaces();
     QStringList infoColumn(const QStringList &summary, const u_char *pkt);
     void addLayerToTree(QTreeWidget *tree, const PacketLayer &lay);
-    
+    void saveAnnotationToFile(const PacketAnnotation &annotation);
+
     PacketColorizer packetColorizer;
 
     QComboBox   *ifaceBox;
@@ -106,13 +126,15 @@ private:
     QMap<QString,int>   protocolCounts;
 
     //charts
-    PieChart     *pieChart;   
+    PieChart     *pieChart;
     std::unique_ptr<Statistics> stats;
     QTimer *statsTimer = nullptr;
 
     //geolocation
     GeoLocation geo;
-    GeoMapWidget *mapWidget = nullptr;  
+    GeoMapWidget *mapWidget = nullptr;
+
+    QVector<PacketAnnotation> annotations;
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
## Summary
- replace the annotation menu action with a reporting workflow that opens an expanded dialog
- allow per-packet tags and highlight colours in the reporting dialog while showing the selected packets
- persist saved reports as JSON files in a reporting/ directory derived from the report title

## Testing
- not run (Qt build tools unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68de85b799208325bad31ae18668bc89