### PR TITLE
Handle Linux cooked capture datalinks and extend protocol parsing

### DIFF
--- a/packets/sniffing.h
+++ b/packets/sniffing.h
@@ -2,7 +2,6 @@
 #define SNIFFING_H
 
 #include <QString>
-#include "src/packetworker.h"
 #include "protocols/proto_struct.h"
 #include <arpa/inet.h>
 #include <netinet/if_ether.h> 
@@ -22,7 +21,7 @@ struct PacketLayer {
     QVector<ProtoField> fields;
 };
 
-class PacketWorker;  
+class PacketWorker;
 
 class Sniffing {
 public:
@@ -33,16 +32,16 @@ public:
                                 const struct pcap_pkthdr *header,
                                 const u_char *packet);
     // === Parsers ====
-    QStringList parseArp(const u_char *pkt) const;
-    QStringList parseTcp(const u_char *pkt) const;
-    QStringList parseUdp(const u_char *pkt) const;
-    QStringList parseIcmp(const u_char *pkt) const;
+    QStringList parseArp(const u_char *pkt, int datalinkType = DLT_EN10MB) const;
+    QStringList parseTcp(const u_char *pkt, int datalinkType = DLT_EN10MB) const;
+    QStringList parseUdp(const u_char *pkt, int datalinkType = DLT_EN10MB) const;
+    QStringList parseIcmp(const u_char *pkt, int datalinkType = DLT_EN10MB) const;
     // ================
 
-    QVector<PacketLayer> parseLayers(const u_char* pkt) const;
+    QVector<PacketLayer> parseLayers(const u_char* pkt, int datalinkType = DLT_EN10MB) const;
 
     QString toHexAscii(const u_char *payload, int len) const;
-    QStringList packetSummary(const u_char *packet, int total_len) const;
+    QStringList packetSummary(const u_char *packet, int total_len, int datalinkType = DLT_EN10MB) const;
 
     //These are for saving and opening my pcap files
     void saveToPcap(const QString &filePath);
@@ -50,9 +49,11 @@ public:
 
     //I will use this to save my packet sniffing session later
     static QVector<QByteArray> packetBuffer;
-    static QMutex packetMutex; 
-    static void appendPacket(const QByteArray &raw);
+    static QVector<int> packetDatalinks;
+    static QMutex packetMutex;
+    static void appendPacket(const QByteArray &raw, int datalinkType = DLT_EN10MB);
     static const QVector<QByteArray>& getAllPackets();
+    static const QVector<int>& getAllDatalinks();
     void clearBuffer();
 
 };

--- a/src/PacketTableModel.h
+++ b/src/PacketTableModel.h
@@ -6,10 +6,12 @@
 #include <QByteArray>
 #include <QStringList>
 #include <QVector>
+#include <pcap.h>
 
 struct PacketTableRow {
     QStringList columns; // column texts: No., Time, Source, Destination, Protocol, Length, Info
     QByteArray rawData;  // packet raw bytes
+    int datalinkType = DLT_EN10MB;
     QColor background;   // background color
 };
 

--- a/src/gui/mainwindow_packets.h
+++ b/src/gui/mainwindow_packets.h
@@ -4,7 +4,7 @@
 
 // void onPacketClicked(int row, int col); //QTableWidget before QTableView
 void onPacketClicked(const QModelIndex &index);
-QStringList infoColumn(const QStringList &parts, const u_char *pkt);
+QStringList infoColumn(const QStringList &parts, const u_char *pkt, int datalinkType);
 void onPacketTableContextMenu(const QPoint &pos);
 void addLayerToTree(QTreeWidget *tree, const PacketLayer &lay);
 void startNewSession();

--- a/src/gui/mainwindow_sniffing.cpp
+++ b/src/gui/mainwindow_sniffing.cpp
@@ -81,7 +81,8 @@ void MainWindow::stopSniffing() {
 }
 
 void MainWindow::handlePacket(const QByteArray &raw,
-                              const QStringList &infos) 
+                              const QStringList &infos,
+                              int datalinkType)
 {
     // == TIME ==
     QDateTime pktTime = QDateTime::currentDateTime();
@@ -103,7 +104,7 @@ void MainWindow::handlePacket(const QByteArray &raw,
                      << time;
 
     const u_char *pkt = reinterpret_cast<const u_char*>(raw.constData());
-    auto parts = parser.packetSummary(pkt, raw.size());
+    auto parts = parser.packetSummary(pkt, raw.size(), datalinkType);
     // parts = { srcIP, dstIP, protoName, lengthStr }
     // for (int c = 2; c < 6; ++c) {
     //     packetTable->setItem(row, c,
@@ -115,13 +116,14 @@ void MainWindow::handlePacket(const QByteArray &raw,
                  << parts.value(2)
                  << parts.value(3);
 
-    QStringList infoValues = infoColumn(parts, pkt);
+    QStringList infoValues = infoColumn(parts, pkt, datalinkType);
 
     // auto *infoItem = new QTableWidgetItem(infoValues.join("  "));
     // infoItem->setData(Qt::UserRole, raw);
     // packetTable->setItem(row, 6, infoItem);  //QTableWidget before QTableView
     tableRow.columns << infoValues.join("  ");
     tableRow.rawData = raw;
+    tableRow.datalinkType = datalinkType;
 
     pcap_pkthdr hdr{{ infos[0].toLongLong(), 0 },
                     (bpf_u_int32)raw.size(),

--- a/src/gui/mainwindow_sniffing.h
+++ b/src/gui/mainwindow_sniffing.h
@@ -5,6 +5,6 @@
 
 void startSniffing();
 void stopSniffing();
-void handlePacket(const QByteArray &raw, const QStringList &infos);
+void handlePacket(const QByteArray &raw, const QStringList &infos, int datalinkType);
 
 #endif //MAINWINDOW_SNIFFING_H

--- a/src/gui/mainwindow_ui.cpp
+++ b/src/gui/mainwindow_ui.cpp
@@ -9,6 +9,7 @@
 #include <QMenu>
 #include <QMenuBar>
 #include <QCoreApplication>
+#include <pcap.h>
 
 void MainWindow::setupUI() {
     // === Central UI ===
@@ -121,10 +122,16 @@ void MainWindow::setupUI() {
         if (!fileName.isEmpty()) {
             parser.openFromPcap(fileName);
 
-            for (const QByteArray &raw : parser.getAllPackets()) {
+            const auto &packets = parser.getAllPackets();
+            const auto &datalinks = parser.getAllDatalinks();
+            for (int i = 0; i < packets.size(); ++i) {
+                const QByteArray &raw = packets.at(i);
+                const int datalink = (i < datalinks.size())
+                    ? datalinks.at(i)
+                    : DLT_EN10MB;
                 QStringList infos;
-                infos << QString::number(0) << QString::number(raw.size()); 
-                handlePacket(raw, infos);
+                infos << QString::number(0) << QString::number(raw.size());
+                handlePacket(raw, infos, datalink);
             }
         }
     });

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -76,7 +76,7 @@ public:
 private slots:
     void startSniffing();
     void stopSniffing();
-    void handlePacket(const QByteArray &raw, const QStringList &infos);
+    void handlePacket(const QByteArray &raw, const QStringList &infos, int datalinkType);
     // void onPacketClicked(int row, int col);
     void onPacketClicked(const QModelIndex &index);
     void showColorizeCustomizer();
@@ -93,7 +93,7 @@ private slots:
 private:
     void setupUI();
     void listInterfaces();
-    QStringList infoColumn(const QStringList &summary, const u_char *pkt);
+    QStringList infoColumn(const QStringList &summary, const u_char *pkt, int datalinkType);
     void addLayerToTree(QTreeWidget *tree, const PacketLayer &lay);
     void saveAnnotationToFile(const PacketAnnotation &annotation);
     void loadPreferences();

--- a/src/packetworker.h
+++ b/src/packetworker.h
@@ -2,7 +2,6 @@
 #define PACKETWORKER_H
 
 #include <QObject>
-#include "packets/sniffing.h"
 #include <QString>
 #include <QThread>
 #include <netinet/in.h>
@@ -35,7 +34,10 @@ signals:
     // rawData: packet bytes
     // infos:   [0]=timestamp, [1]=caplen, [2]=srcPort, [3]=dstPort
     void newPacket(const QByteArray &rawData,
-                   QStringList infos);
+                   QStringList infos,
+                   int datalinkType);
+
+    int datalinkType() const { return m_datalinkType; }
 
 private:
     QString           m_iface;
@@ -44,6 +46,7 @@ private:
     std::atomic<bool> m_running;
     std::unique_ptr<pcap_t, decltype(&pcap_close)> m_handle{nullptr, &pcap_close};
     bpf_u_int32       m_netmask = 0;
+    int               m_datalinkType = DLT_EN10MB;
 };
 
 #endif // PACKETWORKER_H

--- a/src/statistics/sessionstorage.cpp
+++ b/src/statistics/sessionstorage.cpp
@@ -119,6 +119,7 @@ std::optional<LoadedSession> loadSession(const SessionRecord &record)
     Sniffing sniffer;
     sniffer.openFromPcap(record.pcapPath);
     session.packets = Sniffing::getAllPackets();
+    session.datalinks = Sniffing::getAllDatalinks();
     sniffer.clearBuffer();
 
     return session;

--- a/src/statistics/sessionstorage.h
+++ b/src/statistics/sessionstorage.h
@@ -28,6 +28,7 @@ struct LoadedSession {
     SessionRecord record;
     QJsonDocument statsDocument;
     QVector<QByteArray> packets;
+    QVector<int> datalinks;
 };
 
 QString sessionsDirectory();

--- a/tests/tst_sniffing.h
+++ b/tests/tst_sniffing.h
@@ -11,6 +11,7 @@ private slots:
     void parseUdpIpv4();
     void parseIcmpIpv4();
     void parseTcpIpv6();
+    void parseTcpLinuxSll();
     void parseArp();
 };
 


### PR DESCRIPTION
## Summary
- track the datalink type for every captured packet so cooked captures from the `any` interface remain parsable
- update the packet helpers, parsers, and UI consumers to use datalink-aware offsets and display Linux cooked capture headers alongside IPv4/IPv6/TCP/UDP/ICMP/ARP data
- persist datalink metadata in saved sessions and add a unit test covering TCP decoding from a Linux cooked frame

## Testing
- `make SniffingTests` *(fails: /usr/bin/qmake not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dec14d3aa08325807110adccc07cba