### PR TITLE
Add application-layer protocol parsing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ qmake PacketSniffer.pro CONFIG+=release && make -j"$(nproc)"
 make distclean
 ```
 
+## Application Protocol Support
+- HTTP request/response lines and headers are decoded and exposed in the packet details tree.
+- DNS queries and responses include transaction metadata along with parsed questions, answers, authority and additional records.
+- TLS handshakes surface record type, negotiated versions, SNI host names and cipher information for ClientHello/ServerHello messages.
+
 # Ethernet II vs Linux Cooked Capture
 At the moment when packet capturing starts, PacketWorker::process queries libpcap for the data link layer type (pcap_datalink) and passes the result to Sniffing::setLinkLayer. This means that whatever libpcap reports for the active interface directly controls the parsing logic in the application.
 

--- a/packets/sniffing.h
+++ b/packets/sniffing.h
@@ -9,6 +9,7 @@
 #include <QStringList>
 #include <QVector>
 #include <QMutex>
+#include <QtGlobal>
 
 #ifndef DLT_EN10MB
 #define DLT_EN10MB 1
@@ -29,6 +30,62 @@ struct ProtoField {
 struct PacketLayer {
     QString name;
     QVector<ProtoField> fields;
+};
+
+struct HttpHeader {
+    QString name;
+    QString value;
+};
+
+struct ParsedHttp {
+    bool valid = false;
+    bool isRequest = false;
+    QString method;
+    QString target;
+    QString version;
+    int statusCode = 0;
+    QString reason;
+    QString host;
+    QVector<HttpHeader> headers;
+};
+
+struct DnsQuestion {
+    QString name;
+    QString type;
+    QString klass;
+};
+
+struct DnsRecord {
+    QString name;
+    QString type;
+    QString klass;
+    quint32 ttl = 0;
+    QString data;
+};
+
+struct ParsedDns {
+    bool valid = false;
+    bool isResponse = false;
+    quint16 id = 0;
+    quint8 opcode = 0;
+    quint8 rcode = 0;
+    bool authoritative = false;
+    bool truncated = false;
+    QVector<DnsQuestion> questions;
+    QVector<DnsRecord> answers;
+    QVector<DnsRecord> authorities;
+    QVector<DnsRecord> additionals;
+};
+
+struct ParsedTls {
+    bool valid = false;
+    QString recordType;
+    QString version;
+    QString handshakeType;
+    QString serverName;
+    QString selectedCipher;
+    QStringList cipherSuites;
+    bool isClientHello = false;
 };
 
 struct CapturedPacket {
@@ -69,6 +126,9 @@ public:
     QStringList parseIpv6Fragment(const u_char *pkt, int linkType) const;
     QStringList parseIpv6Destination(const u_char *pkt, int linkType) const;
     QStringList parseIpv6Mobility(const u_char *pkt, int linkType) const;
+    ParsedHttp parseHttp(const u_char *pkt, int linkType) const;
+    ParsedDns parseDns(const u_char *pkt, int linkType) const;
+    ParsedTls parseTls(const u_char *pkt, int linkType) const;
     // ================
 
     QVector<PacketLayer> parseLayers(const u_char* pkt, int linkType) const;

--- a/protocols/proto_struct.h
+++ b/protocols/proto_struct.h
@@ -618,6 +618,13 @@ struct sniff_tls_record {  // RFC: 8446 (TLS 1.3 record header)
     uint16_t length;       // Length of TLS payload
 };
 
+struct sniff_tls_handshake { // TLS Handshake header
+    uint8_t  handshake_type; // ClientHello, ServerHello, etc.
+    uint8_t  length_msb;
+    uint8_t  length_mid;
+    uint8_t  length_lsb;
+};
+
 struct sniff_http_request { // Basic HTTP request-line representation
     const char *method;    // Method (GET, POST, ...)
     const char *uri;       // Request URI

--- a/tests/tst_sniffing.cpp
+++ b/tests/tst_sniffing.cpp
@@ -149,11 +149,179 @@ static QByteArray arpPacket()
     return pkt;
 }
 
+
+
+static QByteArray httpRequestPacket()
+{
+    sniff_ethernet eth{};
+    memcpy(eth.ether_dhost, "\x00\x11\x22\x33\x44\x55", 6);
+    memcpy(eth.ether_shost, "\x66\x77\x88\x99\xaa\xbb", 6);
+    eth.ether_type = htons(ETHERTYPE_IP);
+
+    QByteArray httpPayload("GET /index.html HTTP/1.1\r\nHost: example.com\r\n\r\n");
+
+    sniff_ip ip{};
+    ip.ip_vhl = (4 << 4) | 5;
+    ip.ip_len = htons(sizeof(sniff_ip) + sizeof(sniff_tcp) + httpPayload.size());
+    ip.ip_ttl = 64;
+    ip.ip_p = IPPROTO_TCP;
+    ip.ip_src.s_addr = inet_addr("198.51.100.1");
+    ip.ip_dst.s_addr = inet_addr("203.0.113.5");
+
+    sniff_tcp tcp{};
+    tcp.th_sport = htons(49152);
+    tcp.th_dport = htons(80);
+    tcp.th_seq = htonl(1000);
+    tcp.th_ack = htonl(1);
+    tcp.th_offx2 = (5 << 4);
+    tcp.th_flags = TH_PUSH | TH_ACK;
+    tcp.th_win = htons(2048);
+
+    QByteArray pkt;
+    pkt.append(reinterpret_cast<const char*>(&eth), sizeof(eth));
+    pkt.append(reinterpret_cast<const char*>(&ip), sizeof(ip));
+    pkt.append(reinterpret_cast<const char*>(&tcp), sizeof(tcp));
+    pkt.append(httpPayload);
+    return pkt;
+}
+
+static QByteArray dnsQueryPacket()
+{
+    sniff_ethernet eth{};
+    memcpy(eth.ether_dhost, "\x00\x11\x22\x33\x44\x55", 6);
+    memcpy(eth.ether_shost, "\x66\x77\x88\x99\xaa\xbb", 6);
+    eth.ether_type = htons(ETHERTYPE_IP);
+
+    sniff_ip ip{};
+    ip.ip_vhl = (4 << 4) | 5;
+    ip.ip_ttl = 64;
+    ip.ip_p = IPPROTO_UDP;
+    ip.ip_src.s_addr = inet_addr("198.51.100.2");
+    ip.ip_dst.s_addr = inet_addr("203.0.113.8");
+
+    sniff_udp udp{};
+    udp.uh_sport = htons(53000);
+    udp.uh_dport = htons(53);
+
+    sniff_dns dns{};
+    dns.id = htons(0x1a2b);
+    dns.flags = htons(0x0100);
+    dns.q_count = htons(1);
+
+    QByteArray question;
+    question.append(char(0x07));
+    question.append("example", 7);
+    question.append(char(0x03));
+    question.append("com", 3);
+    question.append(char(0x00));
+    question.append(char(0x00));
+    question.append(char(0x01));
+    question.append(char(0x00));
+    question.append(char(0x01));
+
+    quint16 dnsLen = sizeof(sniff_dns) + question.size();
+    udp.uh_len = htons(sizeof(sniff_udp) + dnsLen);
+
+    ip.ip_len = htons(sizeof(sniff_ip) + ntohs(udp.uh_len));
+
+    QByteArray pkt;
+    pkt.append(reinterpret_cast<const char*>(&eth), sizeof(eth));
+    pkt.append(reinterpret_cast<const char*>(&ip), sizeof(ip));
+    pkt.append(reinterpret_cast<const char*>(&udp), sizeof(udp));
+    pkt.append(reinterpret_cast<const char*>(&dns), sizeof(dns));
+    pkt.append(question);
+    return pkt;
+}
+
+static QByteArray tlsClientHelloPacket()
+{
+    sniff_ethernet eth{};
+    memcpy(eth.ether_dhost, "\x00\x11\x22\x33\x44\x55", 6);
+    memcpy(eth.ether_shost, "\x66\x77\x88\x99\xaa\xbb", 6);
+    eth.ether_type = htons(ETHERTYPE_IP);
+
+    QByteArray serverName("example.com");
+
+    QByteArray clientHello;
+    clientHello.append(char(0x03));
+    clientHello.append(char(0x03));
+    clientHello.append(QByteArray(32, '\0'));
+    clientHello.append(char(0x00));
+    clientHello.append(char(0x00));
+    clientHello.append(char(0x02));
+    clientHello.append(char(0x13));
+    clientHello.append(char(0x01));
+    clientHello.append(char(0x01));
+    clientHello.append(char(0x00));
+
+    QByteArray extensions;
+    QByteArray serverNameExt;
+    serverNameExt.append(char(0x00));
+    serverNameExt.append(char(0x00));
+    serverNameExt.append(char(0x00));
+    serverNameExt.append(char(0x10));
+    QByteArray serverNameData;
+    serverNameData.append(char(0x00));
+    serverNameData.append(char(0x0E));
+    serverNameData.append(char(0x00));
+    serverNameData.append(char((serverName.size() >> 8) & 0xFF));
+    serverNameData.append(char(serverName.size() & 0xFF));
+    serverNameData.append(serverName);
+    serverNameExt.append(serverNameData);
+    extensions.append(serverNameExt);
+
+    quint16 extensionsLen = quint16(extensions.size());
+    clientHello.append(char((extensionsLen >> 8) & 0xFF));
+    clientHello.append(char(extensionsLen & 0xFF));
+    clientHello.append(extensions);
+
+    quint32 bodyLen = clientHello.size();
+    QByteArray handshake;
+    handshake.append(char(0x01));
+    handshake.append(char((bodyLen >> 16) & 0xFF));
+    handshake.append(char((bodyLen >> 8) & 0xFF));
+    handshake.append(char(bodyLen & 0xFF));
+    handshake.append(clientHello);
+
+    QByteArray record;
+    record.append(char(0x16));
+    record.append(char(0x03));
+    record.append(char(0x01));
+    quint16 recordLen = quint16(handshake.size());
+    record.append(char((recordLen >> 8) & 0xFF));
+    record.append(char(recordLen & 0xFF));
+    record.append(handshake);
+
+    sniff_ip ip{};
+    ip.ip_vhl = (4 << 4) | 5;
+    ip.ip_len = htons(sizeof(sniff_ip) + sizeof(sniff_tcp) + record.size());
+    ip.ip_ttl = 64;
+    ip.ip_p = IPPROTO_TCP;
+    ip.ip_src.s_addr = inet_addr("198.51.100.3");
+    ip.ip_dst.s_addr = inet_addr("203.0.113.9");
+
+    sniff_tcp tcp{};
+    tcp.th_sport = htons(49153);
+    tcp.th_dport = htons(443);
+    tcp.th_seq = htonl(1);
+    tcp.th_ack = htonl(1);
+    tcp.th_offx2 = (5 << 4);
+    tcp.th_flags = TH_PUSH | TH_ACK;
+    tcp.th_win = htons(4096);
+
+    QByteArray pkt;
+    pkt.append(reinterpret_cast<const char*>(&eth), sizeof(eth));
+    pkt.append(reinterpret_cast<const char*>(&ip), sizeof(ip));
+    pkt.append(reinterpret_cast<const char*>(&tcp), sizeof(tcp));
+    pkt.append(record);
+    return pkt;
+}
+
 void SniffingTest::parseTcpIpv4()
 {
     Sniffing s;
     auto pkt = tcpIpv4Packet();
-    auto vals = s.parseTcp(reinterpret_cast<const u_char*>(pkt.constData()));
+    auto vals = s.parseTcp(reinterpret_cast<const u_char*>(pkt.constData()), DLT_EN10MB);
     QCOMPARE(vals.at(0), QString("192.0.2.1"));
     QCOMPARE(vals.at(1), QString("192.0.2.2"));
     QCOMPARE(vals.at(2), QString("1234"));
@@ -164,7 +332,7 @@ void SniffingTest::parseUdpIpv4()
 {
     Sniffing s;
     auto pkt = udpIpv4Packet();
-    auto vals = s.parseUdp(reinterpret_cast<const u_char*>(pkt.constData()));
+    auto vals = s.parseUdp(reinterpret_cast<const u_char*>(pkt.constData()), DLT_EN10MB);
     QCOMPARE(vals.at(0), QString("192.0.2.1"));
     QCOMPARE(vals.at(1), QString("192.0.2.2"));
     QCOMPARE(vals.at(2), QString("1111"));
@@ -175,7 +343,7 @@ void SniffingTest::parseIcmpIpv4()
 {
     Sniffing s;
     auto pkt = icmpIpv4Packet();
-    auto vals = s.parseIcmp(reinterpret_cast<const u_char*>(pkt.constData()));
+    auto vals = s.parseIcmp(reinterpret_cast<const u_char*>(pkt.constData()), DLT_EN10MB);
     QCOMPARE(vals.at(0), QString("8"));
     QCOMPARE(vals.at(1), QString("0"));
 }
@@ -184,7 +352,7 @@ void SniffingTest::parseTcpIpv6()
 {
     Sniffing s;
     auto pkt = tcpIpv6Packet();
-    auto vals = s.parseTcp(reinterpret_cast<const u_char*>(pkt.constData()));
+    auto vals = s.parseTcp(reinterpret_cast<const u_char*>(pkt.constData()), DLT_EN10MB);
     QCOMPARE(vals.at(0), QString("2001:db8::1"));
     QCOMPARE(vals.at(1), QString("2001:db8::2"));
 }
@@ -193,10 +361,50 @@ void SniffingTest::parseArp()
 {
     Sniffing s;
     auto pkt = arpPacket();
-    auto vals = s.parseArp(reinterpret_cast<const u_char*>(pkt.constData()));
+    auto vals = s.parseArp(reinterpret_cast<const u_char*>(pkt.constData()), DLT_EN10MB);
     QCOMPARE(vals.at(0), QString("192.0.2.1"));
     QCOMPARE(vals.at(1), QString("192.0.2.2"));
     QCOMPARE(vals.at(6), QString("Request"));
+}
+
+void SniffingTest::parseHttpRequest()
+{
+    Sniffing s;
+    auto pkt = httpRequestPacket();
+    ParsedHttp http = s.parseHttp(reinterpret_cast<const u_char*>(pkt.constData()), DLT_EN10MB);
+    QVERIFY(http.valid);
+    QVERIFY(http.isRequest);
+    QCOMPARE(http.method, QStringLiteral("GET"));
+    QCOMPARE(http.target, QStringLiteral("/index.html"));
+    QCOMPARE(http.host, QStringLiteral("example.com"));
+}
+
+void SniffingTest::parseDnsQuery()
+{
+    Sniffing s;
+    auto pkt = dnsQueryPacket();
+    ParsedDns dns = s.parseDns(reinterpret_cast<const u_char*>(pkt.constData()), DLT_EN10MB);
+    QVERIFY(dns.valid);
+    QCOMPARE(dns.id, quint16(0x1a2b));
+    QVERIFY(!dns.isResponse);
+    QCOMPARE(dns.questions.size(), 1);
+    const auto &question = dns.questions.first();
+    QCOMPARE(question.name, QStringLiteral("example.com"));
+    QCOMPARE(question.type, QStringLiteral("A"));
+    QCOMPARE(question.klass, QStringLiteral("IN"));
+}
+
+void SniffingTest::parseTlsClientHello()
+{
+    Sniffing s;
+    auto pkt = tlsClientHelloPacket();
+    ParsedTls tls = s.parseTls(reinterpret_cast<const u_char*>(pkt.constData()), DLT_EN10MB);
+    QVERIFY(tls.valid);
+    QCOMPARE(tls.handshakeType, QStringLiteral("ClientHello"));
+    QCOMPARE(tls.version, QStringLiteral("TLS 1.2"));
+    QVERIFY(tls.isClientHello);
+    QCOMPARE(tls.serverName, QStringLiteral("example.com"));
+    QVERIFY(tls.cipherSuites.contains(QStringLiteral("TLS_AES_128_GCM_SHA256")));
 }
 
 QTEST_MAIN(SniffingTest)

--- a/tests/tst_sniffing.h
+++ b/tests/tst_sniffing.h
@@ -12,6 +12,9 @@ private slots:
     void parseIcmpIpv4();
     void parseTcpIpv6();
     void parseArp();
+    void parseHttpRequest();
+    void parseDnsQuery();
+    void parseTlsClientHello();
 };
 
 #endif // TST_SNIFFING_H


### PR DESCRIPTION
## Summary
- add HTTP, DNS, and TLS parsing helpers and extend layer decoding to expose their metadata
- surface friendly HTTP/DNS/TLS summaries in the packet table info column with translations
- add unit tests and README documentation for the new protocol coverage while removing temporary PCAP fixtures from tests/pcaps

## Testing
- make -C tests *(fails: /usr/bin/qmake: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68dee6e469c483259327d7a202c6ee56